### PR TITLE
Fix EpubNavigatorFragment.goBackward/Forward()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Navigator
+
+#### Fixed
+
+* `EpubNavigatorFragment`'s `goForward()` and `goBackward()` are now jumping to the previous or next pages instead of resources.
+
 
 ## [2.1.0]
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -68,8 +68,8 @@ class R2EpubPageFragment : Fragment() {
         val webView = binding.webView
         this.webView = webView
 
-        webView.navigator = parentFragment as Navigator
-        webView.listener = parentFragment as R2BasicWebView.Listener
+        webView.navigator = navigatorFragment
+        webView.listener = navigatorFragment.webViewListener
         webView.preferences = preferences
 
         webView.setScrollMode(preferences.getBoolean(SCROLL_REF, false))

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -114,8 +114,9 @@ class R2FXLPageFragment : Fragment() {
     @SuppressLint("SetJavaScriptEnabled")
     private fun setupWebView(webView: R2BasicWebView, resourceUrl: String?) {
         webViews.add(webView)
-        webView.navigator = parentFragment as Navigator
-        webView.listener = parentFragment as R2BasicWebView.Listener
+        val navigator = parentFragment as EpubNavigatorFragment
+        webView.navigator = navigator
+        webView.listener = navigator.webViewListener
 
         webView.settings.javaScriptEnabled = true
         webView.isVerticalScrollBarEnabled = false


### PR DESCRIPTION
### Navigator

#### Fixed

* `EpubNavigatorFragment`'s `goForward()` and `goBackward()` are now jumping to the previous or next pages instead of resources.

The implementation was not following the spec of `Navigator`, since it was jumping between resources instead of pages.

```kotlin
    /**
     * Moves to the next content portion (eg. page) in the reading progression direction.
     */
    fun goForward(animated: Boolean = false, completion: () -> Unit = {}): Boolean

    /**
     * Moves to the previous content portion (eg. page) in the reading progression direction.
     */
    fun goBackward(animated: Boolean = false, completion: () -> Unit = {}): Boolean
```

I also made the conformance to `R2BasicWebView.Listener` private in `EpubNavigatorFragment`, to avoid future conflicts.