### PR TITLE
Fix sniffing a JSON Problem Details media type

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpException.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpException.kt
@@ -102,7 +102,7 @@ class HttpException(
 
     /** Response body parsed as a JSON problem details. */
     val problemDetails: ProblemDetails? by lazy {
-        if (body == null || mediaType?.matches(MediaType.PROBLEM_DETAILS) != true) {
+        if (body == null || mediaType?.matches(MediaType.JSON_PROBLEM_DETAILS) != true) {
             return@lazy null
         }
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/http/ProblemDetails.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/http/ProblemDetails.kt
@@ -13,7 +13,6 @@ import org.readium.r2.shared.extensions.optNullableInt
 import org.readium.r2.shared.extensions.optNullableString
 import org.readium.r2.shared.util.logging.WarningLogger
 import org.readium.r2.shared.util.logging.log
-import org.readium.r2.shared.util.mediatype.MediaType
 
 /**
  * Problem Details for HTTP APIs.
@@ -63,7 +62,3 @@ data class ProblemDetails(
     }
 
 }
-
-/** JSON Problem Details JSON object */
-val MediaType.Companion.PROBLEM_DETAILS get() =
-    MediaType("application/problem+json", name = "HTTP Problem Details", fileExtension = "json")

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/MediaType.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/MediaType.kt
@@ -291,6 +291,7 @@ class MediaType(
         val JAVASCRIPT = MediaType("text/javascript", fileExtension = "js")
         val JPEG = MediaType("image/jpeg", fileExtension = "jpeg")
         val JSON = MediaType("application/json")
+        val JSON_PROBLEM_DETAILS = MediaType("application/problem+json", name = "HTTP Problem Details", fileExtension = "json")
         val JXL = MediaType("image/jxl", fileExtension = "jxl")
         val LCP_LICENSE_DOCUMENT = MediaType("application/vnd.readium.lcp.license.v1.0+json", name = "LCP License", fileExtension = "lcpl")
         val LCP_PROTECTED_AUDIOBOOK = MediaType("application/audiobook+lcp", name = "LCP Protected Audiobook", fileExtension = "lcpa")

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt
@@ -352,6 +352,9 @@ object Sniffers {
 
     /** Sniffs a JSON document. */
     suspend fun json(context: SnifferContext): MediaType? {
+        if (context.hasMediaType("application/problem+json")) {
+            return MediaType.JSON_PROBLEM_DETAILS
+        }
         if (context.hasMediaType("application/json")) {
             return MediaType.JSON
         }

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/mediatype/SnifferTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/mediatype/SnifferTest.kt
@@ -282,6 +282,15 @@ class SnifferTest {
     }
 
     @Test
+    fun `sniff JSON problem details`() = runBlocking {
+        assertEquals(MediaType.JSON_PROBLEM_DETAILS, MediaType.of(mediaType = "application/problem+json"))
+        assertEquals(MediaType.JSON_PROBLEM_DETAILS, MediaType.of(mediaType = "application/problem+json; charset=utf-8"))
+
+        // The sniffing of a JSON document should not take precedence over the JSON problem details.
+        assertEquals(MediaType.JSON_PROBLEM_DETAILS, MediaType.ofBytes({ """{"title": "Message"}""".toByteArray() }, mediaType = "application/problem+json"))
+    }
+
+    @Test
     fun `sniff system media types`() = runBlocking {
         shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
         val xlsx = MediaType.parse(


### PR DESCRIPTION
When provided with a JSON document content, the JSON media type was taking precedence during sniffing.

Note that this problem could impact any media type based on JSON if there's no explicit sniffer. For example:

```kotlin
MediaType.ofBytes({ "{}".toByteArray() }, mediaType = "application/whatnot+json"))
```

This will return `application/json` instead of `application/whatnot+json`, because the media type is not known but we can detect a JSON document from the bytes content. Maybe we need a different strategy, for example only returning `application/json` if the media type is more generic (e.g. `application/octet-stream` or `text/plain`).