### PR TITLE
Catch exceptions thrown in ContentResolver.queryProjection()

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/extensions/ContentResolver.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/extensions/ContentResolver.kt
@@ -13,12 +13,11 @@ import android.content.ContentResolver
 import android.net.Uri
 
 internal fun ContentResolver.queryProjection(uri: Uri, projection: String): String? =
-    query(uri, arrayOf(projection), null, null, null)?.use { cursor ->
-        try {
+    tryOrLog<String?> {
+        query(uri, arrayOf(projection), null, null, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
                 return cursor.getString(0)
             }
-        } catch (e: Exception) {}
-
-        return null
+            return null
+        }
     }


### PR DESCRIPTION
Seems like `ContentResolver.query()` can throw exceptions, we got some weird reports in production:

<img width="1243" alt="Screenshot 2021-10-05 at 11 43 57" src="https://user-images.githubusercontent.com/58686775/135999860-0a6147a3-2959-4ded-ac31-1164d93e4aec.png">

