### PR TITLE
Fix OutOfMemory crash when rendering a PDF cover

### DIFF
--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/pdf/PdfiumDocument.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/pdf/PdfiumDocument.kt
@@ -50,10 +50,7 @@ internal class PdfiumDocument(
         core.getTableOfContents(document).map { it.toOutlineNode() }
     }
 
-    companion object {
-
-    }
-
+    companion object
 }
 
 private fun PdfiumCore.renderCover(document: _PdfiumDocument): Bitmap? {
@@ -68,6 +65,9 @@ private fun PdfiumCore.renderCover(document: _PdfiumDocument): Bitmap? {
         return bitmap
 
     } catch (e: Exception) {
+        Timber.e(e)
+        return null
+    } catch (e: OutOfMemoryError) { // We don't want to catch any Error, only OOM.
         Timber.e(e)
         return null
     }


### PR DESCRIPTION
We got some crash reports caused by Out of Memory error when rendering a PDF cover.

<img width="1235" alt="Screenshot 2021-10-05 at 12 18 52" src="https://user-images.githubusercontent.com/58686775/136005106-d7813d82-dd4f-4e2f-9969-5d14d89887ec.png">


