### PR TITLE
Use Dokka and Mkdocs to generate documentation

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,42 @@
+name: Build and deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  LATEST_VERSION: 2.1.0
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dokka
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material mike
+
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+
+      - name: Run Dokka
+        run: ./gradlew dokkaGfmMultiModule
+
+      - name: Run MkDocs
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          mike deploy ${{ env.LATEST_VERSION }}
+          mike set-default ${{ env.LATEST_VERSION }}
+          mike deploy --rebase --push --update-aliases ${{ env.LATEST_VERSION }} latest

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ lint/reports/
 
 # Android Profiling
 *.hprof
+
+# Docs
+docs/readium

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@
 
 buildscript {
     ext.kotlin_version = '1.5.31'
+    ext.dokka_version = '1.5.30'
 
     repositories {
         google()
@@ -18,8 +19,11 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
     }
 }
+
+apply plugin: 'org.jetbrains.dokka'
 
 allprojects {
     repositories {
@@ -32,6 +36,28 @@ allprojects {
     }
 }
 
+subprojects { project ->
+    if (project.name == 'test-app' || project.name == 'readium') return
+    apply plugin: 'org.jetbrains.dokka'
+    tasks.named("dokkaGfmPartial") {
+        dokkaSourceSets {
+            configureEach {
+                reportUndocumented.set(false)
+                skipEmptyPackages.set(false)
+                skipDeprecated.set(true)
+            }
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+task cleanDocs(type: Delete) {
+    delete "${project.rootDir}/docs/readium", "${project.rootDir}/docs/index.md"
+}
+
+tasks.dokkaGfmMultiModule.configure {
+    outputDirectory = new File("${project.rootDir}/docs")
 }

--- a/docs/readium_colors.css
+++ b/docs/readium_colors.css
@@ -1,0 +1,6 @@
+ body {
+   --md-primary-fg-color: #449d44;
+   --md-primary-fg-color--light: #73b02c;
+   --md-primary-fg-color--dark: #255625;
+   --md-accent-fg-color: #73b02c;
+ }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: Readium Kotlin
+
+# Meta tags (placed in header)
+site_description: Readium Kotlin is an Android library for rendering books
+site_author: Readium Foundation
+site_url: https://github.com/readium/kotlin-toolkit
+
+# Repository (add link to repository on each page)
+repo_name: kotlin-toolkit
+repo_url: https://github.com/readium/kotlin-toolkit
+
+# Copyright (shown at the footer)
+copyright: 'Copyright &copy; 2021 Readium Foundation'
+
+# Material theme
+theme:
+  name: 'material'
+  #  favicon: favicon.svg
+  social:
+    - type: 'github'
+      link: 'https://github.com/readium/kotlin-toolkit'
+
+# Extensions
+markdown_extensions:
+  - admonition
+  - codehilite:
+      guess_lang: false
+  - footnotes
+  - meta
+  - def_list
+  - toc:
+      permalink: true
+#  - pymdownx.betterem:
+#      smart_enable: all
+#  - pymdownx.caret
+#  - pymdownx.inlinehilite
+#  - pymdownx.magiclink
+#  - pymdownx.smartsymbols
+#  - pymdownx.superfences
+
+# Dev server binding
+#dev_addr: 127.0.0.1:3001
+
+nav:
+  - Home: migration-guide.md
+  - API Docs:
+      - Navigator: readium/navigator/index.md
+      - Shared: readium/shared/index.md
+      - Streamer: readium/streamer/index.md
+      - LCP: readium/lcp/index.md
+      - OPDS: readium/opds/index.md
+
+extra_css:
+  - readium_colors.css
+
+extra:
+  version:
+    provider: mike
+


### PR DESCRIPTION
NOTE:  This PR is for the branch `main`.  This PR adds a new GitHub action to generate documentation.  It does this by the following:

1. Every time a push is made to the branch `main`, it runs the action.  After installing the dependencies and everything, it runs Dokka to generate markdown files for each of the submodules.
2. After that is complete, Mkdocs/mike is run to transform the markdown to an HTML ready website that is committed to the `gh-pages` branch

Things to keep in mind for the future:

1. Whenever a push is made to `main` for a new release, make sure `update-docs.yml` is updated so that the `LATEST_VERSION` variable is the release number.  Not sure if that version number can be pulled from an gradle file or not
2. Any pushes to main without a change in the release number will simply overwrite the previous documentation for that release number.  This is useful for adding new documentation, changing verbiage in it, etc.