### PR TITLE
Fix broken EPUB navigator when using a proxy

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -72,6 +72,7 @@ class R2EpubPageFragment : Fragment() {
         val webView = binding.webView
         this.webView = webView
 
+        webView.setProxy("", 0, "localhost|0.0.0.0|127.*|[::1]")
         webView.visibility = View.INVISIBLE
         webView.navigator = navigatorFragment
         webView.listener = navigatorFragment.webViewListener


### PR DESCRIPTION
Fix #33 

This solution is discouraged as relying on [private APIs](https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces). I'm opening this PR to have it in the logs.

I couldn't verify if it really works too, as I can't reproduce the original issue.

The real fix would still be to address #34.