### PR TITLE
Allow to disable content injection in the streamer

### DIFF
--- a/readium/streamer/src/main/java/org/readium/r2/streamer/server/Server.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/server/Server.kt
@@ -25,9 +25,17 @@ import java.net.URL
 import java.net.URLDecoder
 import java.util.*
 
-class Server(port: Int, context: Context) : AbstractServer(port, context.applicationContext)
+class Server(
+    port: Int,
+    context: Context,
+    enableReadiumNavigatorSupport: Boolean = true
+) : AbstractServer(port, context.applicationContext, enableReadiumNavigatorSupport)
 
-abstract class AbstractServer(private var port: Int, private val context: Context) : RouterNanoHTTPD("127.0.0.1", port) {
+abstract class AbstractServer(
+    private var port: Int,
+    private val context: Context,
+    private val enableReadiumNavigatorSupport: Boolean = true,
+) : RouterNanoHTTPD("127.0.0.1", port) {
 
     private val MANIFEST_HANDLE = "/manifest"
     private val JSON_MANIFEST_HANDLE = "/manifest.json"
@@ -81,7 +89,7 @@ abstract class AbstractServer(private var port: Int, private val context: Contex
         }
     }
 
-    fun addPublication(publication: Publication, userPropertiesFile: File?): URL? {
+    fun addPublication(publication: Publication, userPropertiesFile: File? = null): URL? {
         return addPublication(publication, null, "/${UUID.randomUUID()}", userPropertiesFile?.path)
     }
 
@@ -92,6 +100,7 @@ abstract class AbstractServer(private var port: Int, private val context: Contex
         val baseUrl = URL(Publication.localBaseUrlOf(filename = filename, port = port))
         val fetcher = ServingFetcher(
             publication,
+            enableReadiumNavigatorSupport,
             userPropertiesPath,
             customResources
         )

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/server/ServingFetcher.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/server/ServingFetcher.kt
@@ -17,21 +17,30 @@ import org.readium.r2.streamer.fetcher.HtmlInjector
 
 internal class ServingFetcher(
     val publication: Publication,
+    private val enableReadiumNavigatorSupport: Boolean,
     userPropertiesPath: String?,
-    customResources: Resources? = null
+    customResources: Resources? = null,
 ) : Fetcher {
 
-    private val htmlInjector: HtmlInjector =
+    private val htmlInjector: HtmlInjector by lazy {
         HtmlInjector(
             publication,
             userPropertiesPath,
             customResources
         )
+    }
 
     override suspend fun links(): List<Link> = emptyList()
 
     override fun get(link: Link): Resource {
         val resource = publication.get(link)
+        return if (enableReadiumNavigatorSupport)
+            transformResourceForReadiumNavigator(resource)
+        else
+            resource
+    }
+
+    private fun transformResourceForReadiumNavigator(resource: Resource): Resource {
         return if (publication.type == Publication.TYPE.EPUB)
             htmlInjector.transform(resource)
         else


### PR DESCRIPTION
Allow to disable injections in the Streamer to break the strong coupling between the streamer and the navigator. Navigator's script names hard-coded in the streamer used to regularly break third-party navigators.