### PR TITLE
Enable source and doc publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,15 @@ subprojects { project ->
             }
         }
     }
+
+    task javadocsJar(type: Jar) {
+        archiveClassifier.set("javadoc")
+    }
+
+    task sourcesJar(type: Jar) {
+        archiveClassifier.set("sources")
+        from "src/main/java", "src/main/resources"
+    }
 }
 
 task clean(type: Delete) {

--- a/readium/lcp/build.gradle
+++ b/readium/lcp/build.gradle
@@ -45,6 +45,9 @@ afterEvaluate {
 
                 groupId = 'com.github.readium'
                 artifactId = 'readium-lcp'
+
+                artifact sourcesJar
+                artifact javadocsJar
             }
         }
     }

--- a/readium/navigator/build.gradle
+++ b/readium/navigator/build.gradle
@@ -49,6 +49,9 @@ afterEvaluate {
 
                 groupId = 'com.github.readium'
                 artifactId = 'readium-navigator'
+
+                artifact sourcesJar
+                artifact javadocsJar
             }
         }
     }

--- a/readium/opds/build.gradle
+++ b/readium/opds/build.gradle
@@ -40,6 +40,9 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.readium'
                 artifactId = 'readium-opds'
+
+                artifact sourcesJar
+                artifact javadocsJar
             }
         }
     }

--- a/readium/shared/build.gradle
+++ b/readium/shared/build.gradle
@@ -45,6 +45,9 @@ afterEvaluate {
 
                 groupId = 'com.github.readium'
                 artifactId = 'readium-shared'
+
+                artifact sourcesJar
+                artifact javadocsJar
             }
         }
     }

--- a/readium/streamer/build.gradle
+++ b/readium/streamer/build.gradle
@@ -45,6 +45,9 @@ afterEvaluate {
 
                 groupId = 'com.github.readium'
                 artifactId = 'readium-streamer'
+
+                artifact sourcesJar
+                artifact javadocsJar
             }
         }
     }


### PR DESCRIPTION
Allow to publish sources and documentation to Maven. I checked this can be used  by hand, and I _think_ it will be usable with Jitpack as well. It would make debugging much easier in apps using Jitpack.