### PR TITLE
Fix OutOfMemoryError during media type sniffing

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContent.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContent.kt
@@ -44,6 +44,9 @@ internal class SnifferFileContent(val file: File) : SnifferContent {
         } catch (e: Exception) {
             Timber.e(e)
             null
+        } catch (e: OutOfMemoryError) { // We don't want to catch any Error, only OOM.
+            Timber.e(e)
+            null
         }
     }
 
@@ -54,7 +57,6 @@ internal class SnifferFileContent(val file: File) : SnifferContent {
             Timber.e(e)
             null
         }
-
 }
 
 /** Used to sniff a bytes array. */

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContext.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContext.kt
@@ -18,6 +18,7 @@ import org.readium.r2.shared.parser.xml.XmlParser
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.util.archive.Archive
 import org.readium.r2.shared.util.archive.DefaultArchiveFactory
+import timber.log.Timber
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.util.*
@@ -86,13 +87,17 @@ class SnifferContext internal constructor(
      * It will extract the charset parameter from the media type hints to figure out an encoding.
      * Otherwise, fallback on UTF-8.
      */
-    suspend fun contentAsString(): String? {
-        if (!loadedContentAsString) {
-            loadedContentAsString = true
-            _contentAsString = content?.read()?.toString(charset ?: Charset.defaultCharset())
+    suspend fun contentAsString(): String? =
+        try {
+            if (!loadedContentAsString) {
+                loadedContentAsString = true
+                _contentAsString = content?.read()?.toString(charset ?: Charset.defaultCharset())
+            }
+            _contentAsString
+        } catch (e: OutOfMemoryError) { // We don't want to catch any Error, only OOM.
+            Timber.e(e)
+            null
         }
-        return _contentAsString
-    }
 
     private var loadedContentAsString: Boolean = false
     private var _contentAsString: String? = null


### PR DESCRIPTION
We got some reports of `OutOfMemoryError` crashes while sniffing a file as a string:

<img width="964" alt="Screen Shot 2021-11-05 at 12 07 31" src="https://user-images.githubusercontent.com/58686775/140501454-27925d12-6866-4da5-8927-402502ac3fca.png">
