### PR TITLE
Navigator: Fix EPUB layout fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * Fixed turning pages of an EPUB reflowable resource with an odd number of columns. A virtual blank trailing column is appended to the resource when displayed as two columns.
+* EPUB: Fallback on `reflowable` if the `presentation.layout` hint is missing from a manifest.
 
 
 ## [2.1.1]

--- a/test-app/src/main/java/org/readium/r2/testapp/reader/ReaderActivity.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/reader/ReaderActivity.kt
@@ -18,10 +18,7 @@ import androidx.fragment.app.FragmentResultListener
 import androidx.fragment.app.commit
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.ViewModelProvider
-import org.readium.r2.shared.publication.Locator
-import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.allAreAudio
-import org.readium.r2.shared.publication.allAreBitmap
+import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.databinding.ActivityReaderBinding
@@ -59,7 +56,7 @@ open class ReaderActivity : AppCompatActivity() {
 
         if (savedInstanceState == null) {
 
-            if (publication.type == Publication.TYPE.EPUB) {
+            if (publication.type == Publication.TYPE.EPUB || publication.readingOrder.allAreHtml) {
                 val baseUrl = requireNotNull(inputData.baseUrl)
                 readerFragment = EpubReaderFragment.newInstance(baseUrl)
 


### PR DESCRIPTION
### Fixed

#### Navigator

* EPUB: Fallback on `reflowable` if the `presentation.layout` hint is missing from a manifest.

Slack discussion for reference: https://readium.slack.com/archives/C703MSTQU/p1636725222048800?thread_ts=1636469403.043000&cid=C703MSTQU