### PR TITLE
Inject JavaScript bundles and Readium CSS with WebPubs

### DIFF
--- a/readium/streamer/src/main/java/org/readium/r2/streamer/server/ServingFetcher.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/server/ServingFetcher.kt
@@ -34,14 +34,7 @@ internal class ServingFetcher(
 
     override fun get(link: Link): Resource {
         val resource = publication.get(link)
-        return if (enableReadiumNavigatorSupport)
-            transformResourceForReadiumNavigator(resource)
-        else
-            resource
-    }
-
-    private fun transformResourceForReadiumNavigator(resource: Resource): Resource {
-        return if (publication.type == Publication.TYPE.EPUB)
+        return if (enableReadiumNavigatorSupport && link.mediaType.isHtml)
             htmlInjector.transform(resource)
         else
             resource


### PR DESCRIPTION
JavaScript and Readium CSS were injected only for publications marked explicitly as EPUB. Instead, this will inject it for any HTML resource.

Note: I'm not yet sure this should be the default behavior for WebPubs.
See https://github.com/readium/webpub-manifest/issues/65#issuecomment-974265084