### PR TITLE
Fix invisible `<audio>` elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file. Take a look
 * EPUB: Fallback on `reflowable` if the `presentation.layout` hint is missing from a manifest.
 * EPUB: Offset of the current selection's `rect` to take into account the vertical padding.
 * Improve backward compatibility of JavaScript files using Babel.
+* [#193](https://github.com/readium/r2-navigator-kotlin/issues/193) Fixed invisible `<audio>` elements.
 
 
 ## [2.1.1]

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -71,6 +71,19 @@ internal class HtmlInjector(
         val endIncludes = mutableListOf<String>()
         val beginIncludes = mutableListOf<String>()
         beginIncludes.add(getHtmlLink("/assets/readium-css/${layout.readiumCSSPath}ReadiumCSS-before.css"))
+
+        // Fix Readium CSS issue with the positioning of <audio> elements.
+        // https://github.com/readium/readium-css/issues/94
+        // https://github.com/readium/r2-navigator-kotlin/issues/193
+        beginIncludes.add("""
+            <style>
+            audio[controls] {
+                width: revert;
+                height: revert;
+            }
+            </style>
+        """.trimIndent())
+
         endIncludes.add(getHtmlLink("/assets/readium-css/${layout.readiumCSSPath}ReadiumCSS-after.css"))
         endIncludes.add(getHtmlScript("/assets/scripts/readium-reflowable.js"))
 

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
@@ -16,7 +16,12 @@ class HtmlInjectorTest {
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
                 <html xmlns="http://www.w3.org/1999/xhtml">
                     <head><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
-
+                <style>
+                audio[controls] {
+                    width: revert;
+                    height: revert;
+                }
+                </style>
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
                     <link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
@@ -49,7 +54,12 @@ class HtmlInjectorTest {
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
                 <html xmlns="http://www.w3.org/1999/xhtml">
                     <head xmlns:xlink="http://www.w3.org/1999/xlink"><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
-
+                <style>
+                audio[controls] {
+                    width: revert;
+                    height: revert;
+                }
+                </style>
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
                     <link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
@@ -80,7 +90,12 @@ class HtmlInjectorTest {
             """
                 <?xml version="1.0" encoding="utf-8"?>
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head xmlns:xlink="http://www.w3.org/1999/xlink"><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
-                <title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                <style>
+                audio[controls] {
+                    width: revert;
+                    height: revert;
+                }
+                </style><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
                 <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
                 <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
                 <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
@@ -101,7 +116,12 @@ class HtmlInjectorTest {
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><HEAD
                  xmlns:xlink="http://www.w3.org/1999/xlink"
                  ><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
-                <title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                <style>
+                audio[controls] {
+                    width: revert;
+                    height: revert;
+                }
+                </style><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
                 <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
                 <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
                 <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>


### PR DESCRIPTION
### Fixed

#### Navigator

* [#193](https://github.com/readium/r2-navigator-kotlin/issues/193) Fixed invisible `<audio>` elements.