### PR TITLE
Deprecate `Link.toLocator()` in favor of `Publication.locatorFromLink()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to this project will be documented in this file. Take a look
 
 * `Publication.type` is now deprecated in favor of the new `Publication.conformsTo()` API which is more accurate.
     * For example, replace `publication.type == Publication.TYPE.EPUB` with `publication.conformsTo(Publication.Profile.EPUB)` before opening a publication with the `EpubNavigatorFragment`.
+* `Link.toLocator()` is deprecated as it may create an incorrect `Locator` if the link `type` is missing.
+    * Use `publication.locatorFromLink()` instead.
 
 ### Fixed
 

--- a/readium/navigator-media2/src/main/java/org/readium/navigator/media2/MediaNavigator.kt
+++ b/readium/navigator-media2/src/main/java/org/readium/navigator/media2/MediaNavigator.kt
@@ -165,7 +165,7 @@ class MediaNavigator private constructor(
      */
     suspend fun go(locator: Locator): Try<Unit, Exception> {
         val itemIndex = publication.readingOrder.indexOfFirstWithHref(locator.href)
-            ?: return Try.failure(Exception.IllegalArgument("Invalid href ${locator.href}."))
+            ?: return Try.failure(Exception.InvalidArgument("Invalid href ${locator.href}."))
         val position = locator.locations.time ?: Duration.ZERO
         Timber.v("Go to locator $locator")
         return seek(itemIndex, position)
@@ -176,7 +176,7 @@ class MediaNavigator private constructor(
      */
     suspend fun go(link: Link): Try<Unit, Exception> {
         val locator = publication.locatorFromLink(link)
-            ?: return Try.failure(Exception.ResourceNotFound(href = link.href))
+            ?: return Try.failure(Exception.InvalidArgument("Resource not found at ${link.href}"))
         return go(locator)
     }
 
@@ -278,15 +278,13 @@ class MediaNavigator private constructor(
         Ongoing
     }
 
-    sealed class Exception(message: String) : kotlin.Exception(message) {
+    sealed class Exception(override val message: String) : kotlin.Exception(message) {
 
         class SessionPlayer internal constructor(
             internal val error: SessionPlayerError
         ) : Exception("${error.name} error occurred in SessionPlayer.")
 
-        class IllegalArgument(message: String): Exception(message)
-
-        class ResourceNotFound(val href: String) : Exception("Resource not found at $href")
+        class InvalidArgument(message: String): Exception(message)
     }
 
     /*

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/audiobook/R2AudiobookActivity.kt
@@ -78,7 +78,8 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
     }
 
     override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        val locator = publication.locatorFromLink(link) ?: return false
+        return go(locator)
     }
 
     override fun goForward(animated: Boolean, completion: () -> Unit): Boolean {
@@ -156,7 +157,7 @@ open class R2AudiobookActivity : AppCompatActivity(), CoroutineScope, IR2Activit
         if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
 
             if (!loadedInitialLocator) {
-                go(publication.readingOrder.first().toLocator())
+                go(publication.readingOrder.first())
             }
 
             binding.seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -327,7 +327,8 @@ class EpubNavigatorFragment private constructor(
     }
 
     override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean {
-        return go(link.toLocator(), animated, completion)
+        val locator = publication.locatorFromLink(link) ?: return false
+        return go(locator, animated, completion)
     }
 
     private fun run(commands: List<RunScriptCommand>) {
@@ -638,7 +639,9 @@ class EpubNavigatorFragment private constructor(
         get() = publication.metadata.effectiveReadingProgression
 
     override val currentLocator: StateFlow<Locator> get() = _currentLocator
-    private val _currentLocator = MutableStateFlow(initialLocator ?: publication.readingOrder.first().toLocator())
+    private val _currentLocator = MutableStateFlow(initialLocator
+        ?: requireNotNull(publication.locatorFromLink(publication.readingOrder.first()))
+    )
 
     /**
      * While scrolling we receive a lot of new current locations, so we use a coroutine job to

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -60,7 +60,9 @@ class ImageNavigatorFragment private constructor(
     private lateinit var currentActivity: FragmentActivity
 
     override val currentLocator: StateFlow<Locator> get() = _currentLocator
-    private val _currentLocator = MutableStateFlow(initialLocator ?: publication.readingOrder.first().toLocator())
+    private val _currentLocator = MutableStateFlow(initialLocator
+        ?: requireNotNull(publication.locatorFromLink(publication.readingOrder.first()))
+    )
 
     internal var currentPagerPosition: Int = 0
     internal var resources: List<String> = emptyList()
@@ -164,8 +166,10 @@ class ImageNavigatorFragment private constructor(
         return true
     }
 
-    override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean =
-        go(link.toLocator(), animated, completion)
+    override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean {
+        val locator = publication.locatorFromLink(link) ?: return false
+        return go(locator, animated, completion)
+    }
 
     override fun goForward(animated: Boolean, completion: () -> Unit): Boolean {
         val current = resourcePager.currentItem

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaService.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaService.kt
@@ -139,7 +139,9 @@ open class MediaService : MediaBrowserServiceCompat(), CoroutineScope by MainSco
             }
 
             val locator = (extras?.getParcelable(EXTRA_LOCATOR) as? Locator)
-                ?: href?.let { navigator.publication.linkWithHref(it)?.toLocator() }
+                ?: href
+                    ?.let { navigator.publication.linkWithHref(it) }
+                    ?.let { navigator.publication.locatorFromLink(it) }
 
             if (locator != null && href != null && locator.href != href) {
                 Timber.e("Ambiguous playback location provided. HREF `$href` doesn't match locator $locator.")
@@ -310,7 +312,12 @@ open class MediaService : MediaBrowserServiceCompat(), CoroutineScope by MainSco
             val navigator = MediaSessionNavigator(publication, publicationId, getMediaSession(context, serviceClass).controller)
             pendingNavigator.trySend(PendingNavigator(
                 navigator = navigator,
-                media = PendingMedia(publication, publicationId, locator = initialLocator ?: publication.readingOrder.first().toLocator())
+                media = PendingMedia(
+                    publication = publication,
+                    publicationId = publicationId,
+                    locator = initialLocator
+                        ?: requireNotNull(publication.locatorFromLink(publication.readingOrder.first()))
+                )
             ))
 
             return navigator

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaSessionNavigator.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaSessionNavigator.kt
@@ -158,7 +158,7 @@ class MediaSessionNavigator(
     private suspend fun createLocator(position: Duration?, metadata: MediaMetadataCompat?): Locator? {
         val href = metadata?.resourceHref ?: return null
         val index = publication.readingOrder.indexOfFirstWithHref(href) ?: return null
-        var locator = publication.readingOrder[index].toLocator()
+        var locator = publication.locatorFromLink(publication.readingOrder[index]) ?: return null
 
         if (position != null) {
             val startPosition = durations.slice(0 until index).sum()
@@ -186,8 +186,10 @@ class MediaSessionNavigator(
         return true
     }
 
-    override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean =
-        go(link.toLocator(), animated, completion)
+    override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean {
+        val locator = publication.locatorFromLink(link) ?: return false
+        return go(locator, animated, completion)
+    }
 
     override fun goForward(animated: Boolean, completion: () -> Unit): Boolean {
         if (!isActive) return false

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
@@ -180,7 +180,9 @@ class PdfNavigatorFragment internal constructor(
     // Navigator
 
     override val currentLocator: StateFlow<Locator> get() = _currentLocator
-    private val _currentLocator = MutableStateFlow(initialLocator ?: publication.readingOrder.first().toLocator())
+    private val _currentLocator = MutableStateFlow(initialLocator
+        ?: requireNotNull(publication.locatorFromLink(publication.readingOrder.first()))
+    )
 
     override fun go(locator: Locator, animated: Boolean, completion: () -> Unit): Boolean {
         listener?.onJumpToLocator(locator)
@@ -189,8 +191,10 @@ class PdfNavigatorFragment internal constructor(
         return goToHref(locator.href, pageNumberToIndex(pageNumber), animated, completion)
     }
 
-    override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean =
-        go(link.toLocator(), animated = animated, completion = completion)
+    override fun go(link: Link, animated: Boolean, completion: () -> Unit): Boolean {
+        val locator = publication.locatorFromLink(link) ?: return false
+        return go(locator, animated, completion)
+    }
 
     override fun goForward(animated: Boolean, completion: () -> Unit): Boolean {
         val page = pageIndexToNumber(pdfView.currentPage)

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
@@ -200,6 +200,7 @@ data class Locator(
 /**
  * Creates a [Locator] from a reading order [Link].
  */
+@Deprecated("This may create an incorrect `Locator` if the link `type` is missing. Use `publication.locatorFromLink()` instead.")
 fun Link.toLocator(): Locator {
     val components = href.split("#", limit = 2)
     return Locator(

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Manifest.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Manifest.kt
@@ -65,6 +65,38 @@ data class Manifest(
     }
 
     /**
+     * Finds the first [Link] with the given HREF in the manifest's links.
+     *
+     * Searches through (in order) [readingOrder], [resources] and [links] recursively following
+     * alternate and children links.
+     *
+     * If there's no match, try again after removing any query parameter and anchor from the
+     * given [href].
+     */
+    fun linkWithHref(href: String): Link? {
+        fun List<Link>.deepLinkWithHref(href: String): Link? {
+            for (l in this) {
+                if (l.href == href)
+                    return l
+                else {
+                    l.alternates.deepLinkWithHref(href)?.let { return it }
+                    l.children.deepLinkWithHref(href)?.let { return it }
+                }
+            }
+            return null
+        }
+
+        fun find(href: String): Link? {
+            return readingOrder.deepLinkWithHref(href)
+                ?: resources.deepLinkWithHref(href)
+                ?: links.deepLinkWithHref(href)
+        }
+
+        return find(href)
+            ?: find(href.takeWhile { it !in "#?" })
+    }
+
+    /**
      * Finds the first [Link] with the given relation in the manifest's links.
      */
     fun linkWithRel(rel: String): Link? =
@@ -77,6 +109,29 @@ data class Manifest(
      */
     fun linksWithRel(rel: String): List<Link> =
         (readingOrder + resources + links).filterByRel(rel)
+
+    /**
+     * Creates a new [Locator] object from a [Link] to a resource of this manifest.
+     *
+     * Returns null if the resource is not found in this manifest.
+     */
+    fun locatorFromLink(link: Link): Locator? {
+        val components = link.href.split("#", limit = 2)
+        val href = components.firstOrNull() ?: link.href
+        val resourceLink = linkWithHref(href) ?: return null
+        val type = resourceLink.type ?: return null
+        val fragment = components.getOrNull(1)
+
+        return Locator(
+            href = href,
+            type = type,
+            title = resourceLink.title ?: link.title,
+            locations = Locator.Locations(
+                fragments = listOfNotNull(fragment),
+                progression = if (fragment == null) 0.0 else null
+            )
+        )
+    }
 
     /**
      * Serializes a [Publication] to its RWPM JSON representation.

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/services/search/StringSearchService.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/services/search/StringSearchService.kt
@@ -129,9 +129,8 @@ class StringSearchService(
                 return emptyList()
 
             val resourceTitle = publication.tableOfContents.titleMatching(link.href)
-            val resourceLocator = link.toLocator().copy(
-                title = resourceTitle ?: link.title
-            )
+            var resourceLocator = publication.locatorFromLink(link) ?: return emptyList()
+            resourceLocator = resourceLocator.copy(title = resourceTitle ?: resourceLocator.title)
             val locators = mutableListOf<Locator>()
 
             withContext(Dispatchers.IO) {

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/LocatorTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/LocatorTest.kt
@@ -60,29 +60,6 @@ class LocatorTest {
         assertNull(Locator.fromJSON(JSONObject("{ 'invalid': 'object' }")))
     }
 
-    @Test fun `create {Locator} from minimal {Link}`() {
-        assertEquals(
-            Locator(href = "http://locator", type = ""),
-            Link(href = "http://locator").toLocator()
-        )
-    }
-
-    @Test fun `create {Locator} from full {Link} with fragment`() {
-        assertEquals(
-            Locator(
-                href = "http://locator",
-                type = "text/html",
-                title = "My Link",
-                locations = Locator.Locations(fragments = listOf("page=42"))
-            ),
-            Link(
-                href = "http://locator#page=42",
-                type = "text/html",
-                title = "My Link"
-            ).toLocator()
-        )
-    }
-
     @Test fun `get {Locator} minimal JSON`() {
         assertJSONEquals(
             JSONObject("""{

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/ManifestTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/ManifestTest.kt
@@ -332,4 +332,65 @@ class ManifestTest {
         )
     }
 
+    @Test fun `get a {Locator} from a minimal {Link}`() {
+        val manifest = Manifest(
+            metadata = Metadata(localizedTitle = LocalizedString()),
+            readingOrder = listOf(Link(href = "/href", type = "text/html", title = "Resource"))
+        )
+        Assert.assertEquals(
+            Locator(href = "/href", type = "text/html", title = "Resource", locations = Locator.Locations(progression = 0.0)),
+            manifest.locatorFromLink(Link(href = "/href"))
+        )
+    }
+
+    @Test fun `get a {Locator} from a link in the reading order, resources or links`() {
+        val manifest = Manifest(
+            metadata = Metadata(localizedTitle = LocalizedString()),
+            readingOrder = listOf(Link(href = "/href1", type = "text/html")),
+            resources = listOf(Link(href = "/href2", type = "text/html")),
+            links = listOf(Link(href = "/href3", type = "text/html")),
+        )
+        Assert.assertEquals(
+            Locator(href = "/href1", type = "text/html", locations = Locator.Locations(progression = 0.0)),
+            manifest.locatorFromLink(Link(href = "/href1"))
+        )
+        Assert.assertEquals(
+            Locator(href = "/href2", type = "text/html", locations = Locator.Locations(progression = 0.0)),
+            manifest.locatorFromLink(Link(href = "/href2"))
+        )
+        Assert.assertEquals(
+            Locator(href = "/href3", type = "text/html", locations = Locator.Locations(progression = 0.0)),
+            manifest.locatorFromLink(Link(href = "/href3"))
+        )
+    }
+
+    @Test fun `get a {Locator} from a full {Link} with fragment`() {
+        val manifest = Manifest(
+            metadata = Metadata(localizedTitle = LocalizedString()),
+            readingOrder = listOf(Link(href = "/href", type = "text/html", title = "Resource"))
+        )
+        Assert.assertEquals(
+            Locator(href = "/href", type = "text/html", title = "Resource", locations = Locator.Locations(fragments = listOf("page=42"))),
+            manifest.locatorFromLink(Link(href = "/href#page=42", type = "text/xml", title = "My link"))
+        )
+    }
+
+    @Test fun `get a {Locator} falling back on the {Link} title`() {
+        val manifest = Manifest(
+            metadata = Metadata(localizedTitle = LocalizedString()),
+            readingOrder = listOf(Link(href = "/href", type = "text/html"))
+        )
+        Assert.assertEquals(
+            Locator(href = "/href", type = "text/html", title = "My link", locations = Locator.Locations(fragments = listOf("page=42"))),
+            manifest.locatorFromLink(Link(href = "/href#page=42", type = "text/xml", title = "My link"))
+        )
+    }
+
+    @Test fun `get a {Locator} from a {Link} not found in the manifest`() {
+        val manifest = Manifest(
+            metadata = Metadata(localizedTitle = LocalizedString()),
+            readingOrder = listOf(Link(href = "/href", type = "text/html"))
+        )
+        Assert.assertNull(manifest.locatorFromLink(Link(href = "notfound")))
+    }
 }

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
@@ -395,7 +395,6 @@ class PublicationTest {
         assertEquals("test passed", runBlocking { publication.get(link).readAsString().getOrNull() })
     }
 
-    @Suppress("DEPRECATION")
     @Test fun `find the first resource {Link} with the given {href}`() {
         val link1 = Link(href = "href1")
         val link2 = Link(href = "href2")
@@ -406,14 +405,13 @@ class PublicationTest {
             resources = listOf(Link(href = "other"), link3)
         )
 
-        assertNull(publication.resourceWithHref("href1"))
-        assertEquals(link2, publication.resourceWithHref("href2"))
-        assertEquals(link3, publication.resourceWithHref("href3"))
+        assertEquals(link1, publication.linkWithHref("href1"))
+        assertEquals(link2, publication.linkWithHref("href2"))
+        assertEquals(link3, publication.linkWithHref("href3"))
     }
 
-    @Suppress("DEPRECATION")
     @Test fun `find the first resource {Link} with the given {href} when missing`() {
-        assertNull(createPublication().resourceWithHref("foobar"))
+        assertNull(createPublication().linkWithHref("foobar"))
     }
 
     @Suppress("DEPRECATION")

--- a/test-app/src/main/java/org/readium/r2/testapp/outline/NavigationFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/outline/NavigationFragment.kt
@@ -83,13 +83,7 @@ class NavigationFragment : Fragment() {
     }
 
     private fun onLinkSelected(link: Link) {
-        val locator = link.toLocator().let {
-            // progression is mandatory in some contexts
-            if (it.locations.fragments.isEmpty())
-                it.copyWithLocations(progression = 0.0)
-            else
-                it
-        }
+        val locator = publication.locatorFromLink(link) ?: return
 
         setFragmentResult(
             OutlineContract.REQUEST_KEY,

--- a/test-app/src/main/java/org/readium/r2/testapp/tts/ScreenReaderEngine.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/tts/ScreenReaderEngine.kt
@@ -142,7 +142,7 @@ class ScreenReaderEngine(val context: Context, val publication: Publication) {
     }
 
     val currentLocator: Locator
-        get() = publication.readingOrder[resourceIndex].toLocator()
+        get() = requireNotNull(publication.locatorFromLink(publication.readingOrder[resourceIndex]))
 
     /**
      * - Update the resource index.


### PR DESCRIPTION
### Deprecated

#### Shared

* `Link.toLocator()` is deprecated as it may create an incorrect `Locator` if the link `type` is missing.
    * Use `publication.locatorFromLink()` instead.

---

See Slack discussion for context: https://readium.slack.com/archives/C703MSTQU/p1642520174001200