### PR TITLE
Move the Gradle plugins versions into `settings.gradle.kts`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,10 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.application") version ("7.1.0") apply false
-    id("com.android.library") version ("7.1.0") apply false
-    id("org.jetbrains.kotlin.android") version ("1.6.10") apply false
-    id("org.jetbrains.dokka") version ("1.6.10") apply true
+    id("com.android.application") apply false
+    id("com.android.library") apply false
+    id("org.jetbrains.kotlin.android") apply false
+    id("org.jetbrains.dokka") apply true
 }
 
 subprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,13 @@ pluginManagement {
         maven(url = "https://jitpack.io")
         maven(url = "https://s3.amazonaws.com/repo.commonsware.com")
     }
+
+    plugins {
+        id("com.android.application") version ("7.1.0")
+        id("com.android.library") version ("7.1.0")
+        id("org.jetbrains.kotlin.android") version ("1.6.10")
+        id("org.jetbrains.dokka") version ("1.6.10")
+    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
While integrating the latest Kotlin toolkit using the Gradle Kotlin DSL as a Git submodule, I faced this error:
<img width="1429" alt="Screenshot 2022-03-24 at 16 41 58" src="https://user-images.githubusercontent.com/58686775/159967449-d1f7553f-1518-4b32-8f66-ca23124e4d2f.png">

According to [this Gradle forum post](https://discuss.gradle.org/t/error-plugin-already-on-the-classpath-must-not-include-a-version/31814/5), we can fix this by moving the version management to `settings.gradle.kts` instead.

Some additional info from the official documentation: https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_version_management