### PR TITLE
Allow to disable display cutouts padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this project will be documented in this file. Take a look
 * The new `Navigator.Listener.onJumpToLocator()` API is called every time the navigator jumps to an explicit location, which might break the linear reading progression.
     * For example, it is called when clicking on internal links or programmatically calling `Navigator.go()`, but not when turning pages.
     * You can use this callback to implement a navigation history by differentiating between continuous and discontinuous moves.
+* You can now disable the display cutouts padding in the EPUB navigator (contributed by [@szymn](https://github.com/readium/kotlin-toolkit/pull/101)).
+    * This is useful when the navigator is not laid out full screen.
 * (*experimental*) A new audiobook navigator based on Jetpack `media2`.
     * See the [pull request #80](https://github.com/readium/kotlin-toolkit/pull/80) for the differences with the previous audiobook navigator.
     * This navigator is located in its own module `readium-navigator-media2`. You will need to add it to your dependencies to use it.

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -72,7 +72,6 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
     }
 
     lateinit var listener: Listener
-    lateinit var navigator: Navigator
     internal var preferences: SharedPreferences? = null
 
     var resourceUrl: String? = null

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -86,7 +86,7 @@ class EpubNavigatorFragment private constructor(
         /**
          * Whether padding accounting for display cutouts should be applied.
          */
-        var shouldApplyInsetsPadding: Boolean? = true,
+        val shouldApplyInsetsPadding: Boolean? = true,
     )
 
     interface PaginationListener {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -82,6 +82,11 @@ class EpubNavigatorFragment private constructor(
          * Provide one if you want to customize the selection context menu items.
          */
         var selectionActionModeCallback: ActionMode.Callback? = null,
+
+        /**
+         * Whether padding accounting for display cutouts should be applied.
+         */
+        var shouldApplyInsetsPadding: Boolean? = true,
     )
 
     interface PaginationListener {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -62,12 +62,14 @@ class R2EpubPageFragment : Fragment() {
 
     private var isLoading: Boolean = false
 
+    private val navigator: EpubNavigatorFragment?
+        get() = parentFragment as? EpubNavigatorFragment
+
     private val shouldApplyInsetsPadding: Boolean
-        get() = (webView?.navigator as? EpubNavigatorFragment)?.config?.shouldApplyInsetsPadding ?: true
+        get() = navigator?.config?.shouldApplyInsetsPadding ?: true
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val navigatorFragment = parentFragment as EpubNavigatorFragment
         _binding = ViewpagerFragmentEpubBinding.inflate(inflater, container, false)
         containerView = binding.root
         preferences = activity?.getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)!!
@@ -76,8 +78,9 @@ class R2EpubPageFragment : Fragment() {
         this.webView = webView
 
         webView.visibility = View.INVISIBLE
-        webView.navigator = navigatorFragment
-        webView.listener = navigatorFragment.webViewListener
+        navigator?.let {
+            webView.listener = it.webViewListener
+        }
         webView.preferences = preferences
 
         webView.setScrollMode(preferences.getBoolean(SCROLL_REF, false))
@@ -273,7 +276,7 @@ class R2EpubPageFragment : Fragment() {
     internal val paddingBottom: Int get() = containerView.paddingBottom
 
     private val isCurrentResource: Boolean get() {
-        val epubNavigator = webView?.navigator as? EpubNavigatorFragment ?: return false
+        val epubNavigator = navigator ?: return false
         val currentFragment = (epubNavigator.resourcePager.adapter as? R2PagerAdapter)?.getCurrentFragment() as? R2EpubPageFragment ?: return false
         return tag == currentFragment.tag
     }
@@ -289,7 +292,7 @@ class R2EpubPageFragment : Fragment() {
             webView.visibility = View.VISIBLE
 
             if (isCurrentResource) {
-                val epubNavigator = requireNotNull(webView.navigator as? EpubNavigatorFragment)
+                val epubNavigator = requireNotNull(navigator)
                 val locator = epubNavigator.pendingLocator
                 epubNavigator.pendingLocator = null
                 if (locator != null) {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -62,6 +62,9 @@ class R2EpubPageFragment : Fragment() {
 
     private var isLoading: Boolean = false
 
+    private val shouldApplyInsetsPadding: Boolean
+        get() = (webView?.navigator as? EpubNavigatorFragment)?.config?.shouldApplyInsetsPadding ?: true
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val navigatorFragment = parentFragment as EpubNavigatorFragment
@@ -225,11 +228,13 @@ class R2EpubPageFragment : Fragment() {
             }
         }
 
-        // Update padding when the window insets change, for example when the navigation and status
-        // bars are toggled.
-        ViewCompat.setOnApplyWindowInsetsListener(containerView) { _, insets ->
-            updatePadding()
-            insets
+        if (shouldApplyInsetsPadding) {
+            // Update padding when the window insets change, for example when the navigation and status
+            // bars are toggled.
+            ViewCompat.setOnApplyWindowInsetsListener(containerView) { _, insets ->
+                updatePadding()
+                insets
+            }
         }
     }
 
@@ -241,6 +246,7 @@ class R2EpubPageFragment : Fragment() {
 
             // Add additional padding to take into account the display cutout, if needed.
             if (
+                shouldApplyInsetsPadding &&
                 android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P &&
                 window.attributes.layoutInDisplayCutoutMode != WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
             ) {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -20,8 +20,6 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.fragment.app.Fragment
 import androidx.webkit.WebViewClientCompat
-import org.readium.r2.navigator.Navigator
-import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2BasicWebView
 import org.readium.r2.navigator.databinding.FragmentFxllayoutDoubleBinding
 import org.readium.r2.navigator.databinding.FragmentFxllayoutSingleBinding
@@ -44,6 +42,9 @@ class R2FXLPageFragment : Fragment() {
 
     private var _singleBinding: FragmentFxllayoutSingleBinding? = null
     private val singleBinding get() = _singleBinding!!
+
+    private val navigator: EpubNavigatorFragment?
+        get() = parentFragment as? EpubNavigatorFragment
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -114,9 +115,9 @@ class R2FXLPageFragment : Fragment() {
     @SuppressLint("SetJavaScriptEnabled")
     private fun setupWebView(webView: R2BasicWebView, resourceUrl: String?) {
         webViews.add(webView)
-        val navigator = parentFragment as EpubNavigatorFragment
-        webView.navigator = navigator
-        webView.listener = navigator.webViewListener
+        navigator?.let {
+            webView.listener = it.webViewListener
+        }
 
         webView.settings.javaScriptEnabled = true
         webView.isVerticalScrollBarEnabled = false


### PR DESCRIPTION
We have a situation where:
1. we embed the navigator (not full screen)
2. our host activity already handles insets and we want it to keep using LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES

In this scenario we want to avoid additional padding applied for insets within the reader.