### PR TITLE
Associate the `HttpResponse` with the source `HttpRequest`

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/http/DefaultHttpClient.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/http/DefaultHttpClient.kt
@@ -120,6 +120,7 @@ class DefaultHttpClient constructor(
                     }
 
                     val response = HttpResponse(
+                        request = request,
                         url = connection.url.toString(),
                         statusCode = statusCode,
                         headers = connection.safeHeaders,

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpClient.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpClient.kt
@@ -95,6 +95,7 @@ class HttpFetchResponse(
 /**
  * Represents a successful HTTP response received from a server.
  *
+ * @param request Request associated with the response.
  * @param url Final URL of the response.
  * @param statusCode Response status code.
  * @param headers HTTP response headers, indexed by their name.
@@ -102,6 +103,7 @@ class HttpFetchResponse(
  *        on `application/octet-stream`.
  */
 data class HttpResponse(
+    val request: HttpRequest,
     val url: String,
     val statusCode: Int,
     val headers: Map<String, List<String>>,


### PR DESCRIPTION
This is useful to get access to the original request HTTP headers or the `extras` bundle.

I used this in the context of [Authentication for OPDS](https://drafts.opds.io/authentication-for-opds-1.0.html), to retrieve the Authentication Document identifier from the request's `extras`.

Twin Swift PR: https://github.com/readium/swift-toolkit/pull/31