### PR TITLE
Fix EPUB `currentLocator` update when `positions` are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
-### Streamer
+### Added
 
-#### Fixed
+#### Shared
+
+* Add a new `Locator.Builder` object to progressively construct an immutable `Locator` object.
+
+### Fixed
+
+#### Streamer
 
 * Fixed parsing the table of contents of an EPUB 3 using NCX instead of a Navigation Document.
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -343,7 +343,7 @@ class EpubNavigatorFragment private constructor(
 
         resourcePager.adapter = adapter
 
-        if (publication.metadata.presentation.layout == EpubLayout.REFLOWABLE) {
+        if (publication.metadata.presentation.layout != EpubLayout.FIXED) {
             pendingLocator = locator
             setCurrent(resourcesSingle)
         } else {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -52,6 +52,7 @@ import org.readium.r2.shared.publication.presentation.presentation
 import org.readium.r2.shared.publication.services.isRestricted
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
 import org.readium.r2.shared.util.launchWebBrowser
+import org.readium.r2.shared.util.mediatype.MediaType
 import kotlin.math.ceil
 import kotlin.reflect.KClass
 
@@ -696,19 +697,26 @@ class EpubNavigatorFragment private constructor(
             webView.updateCurrentItem()
 
             val resource = publication.readingOrder[resourcePager.currentItem]
-            val progression = webView.progression.coerceIn(0.0, 1.0)
-            val positions = publication.positionsByResource[resource.href]?.takeIf { it.isNotEmpty() }
-                    ?: return@launch
+            val builder = Locator.Builder(
+                href = resource.href,
+                type = resource.type ?: MediaType.XHTML.toString(),
+            )
 
-            val positionIndex = ceil(progression * (positions.size - 1)).toInt()
-            if (!positions.indices.contains(positionIndex)) {
-                return@launch
+            val progression = webView.progression.coerceIn(0.0, 1.0)
+            builder.locations.progression = progression
+
+            val positions = publication.positionsByResource[resource.href]
+                ?.takeIf { it.isNotEmpty() }
+            if (positions != null) {
+                val index = ceil(progression * (positions.size - 1)).toInt()
+                positions.getOrNull(index)
+                    ?.let { builder.merge(it) }
             }
 
-            val locator = positions[positionIndex]
-                    .copy(title = tableOfContentsTitleByHref[resource.href])
-                    .copyWithLocations(progression = progression)
+            tableOfContentsTitleByHref[resource.href]
+                ?.let { builder.title = it }
 
+            val locator = builder.build()
             _currentLocator.value = locator
 
             // Deprecated notifications

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/LocatorTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/LocatorTest.kt
@@ -93,6 +93,28 @@ class LocatorTest {
         )
     }
 
+    @Test fun `copy a {Locator} using a builder`() {
+        assertEquals(
+            Locator(
+                href = "modified-file.html",
+                type = "text/html",
+                title = "Title",
+                locations = Locator.Locations(
+                    progression = 0.5,
+                ),
+                text = Locator.Text(
+                    highlight = "highlight",
+                )
+            ),
+            Locator(href = "href.html", type = "text/html").copy {
+                href = "modified-file.html"
+                title = "Title"
+                locations.progression = 0.5
+                text.highlight = "highlight"
+            }
+        )
+    }
+
     @Test fun `copy a {Locator} with different {Locations} sub-properties`() {
         assertEquals(
             Locator(
@@ -485,4 +507,147 @@ class LocatorCollectionTest {
         )
     }
 
+    @Test fun `build a minimal Locator`() {
+        assertEquals(
+            Locator(href = "file.html", type = "text/html"),
+            Locator.Builder(href = "file.html", type = "text/html").build()
+        )
+    }
+
+    @Test fun `build a full Locator`() {
+        assertEquals(
+            Locator(
+                href = "file.html",
+                type = "text/html",
+                title = "Title",
+                locations = Locator.Locations(
+                    fragments = listOf("fragment"),
+                    progression = 0.5,
+                    position = 42,
+                    totalProgression = 0.2,
+                    otherLocations = mapOf("other" to "location")
+                ),
+                text = Locator.Text(
+                    before = "before",
+                    highlight = "highlight",
+                    after = "after"
+                )
+            ),
+            Locator.Builder(
+                href = "file.html",
+                type = "text/html",
+                title = "Title",
+                locations = Locator.Locations.Builder(
+                    fragments = mutableListOf("fragment"),
+                    progression = 0.5,
+                    position = 42,
+                    totalProgression = 0.2,
+                    otherLocations = mutableMapOf("other" to "location")
+                ),
+                text = Locator.Text.Builder(
+                    before = "before",
+                    highlight = "highlight",
+                    after = "after"
+                )
+            ).build()
+        )
+    }
+
+    @Test fun `merge a minimal Locator into a builder`() {
+        assertEquals(
+            Locator(
+                href = "merged-file.html",
+                type = "merged-text/html",
+                title = "Title",
+                locations = Locator.Locations(
+                    fragments = listOf("fragment"),
+                    progression = 0.5,
+                    position = 42,
+                    totalProgression = 0.2,
+                    otherLocations = mapOf("other" to "location")
+                ),
+                text = Locator.Text(
+                    before = "before",
+                    highlight = "highlight",
+                    after = "after"
+                )
+            ),
+            Locator.Builder(
+                href = "file.html",
+                type = "text/html",
+                title = "Title",
+                locations = Locator.Locations.Builder(
+                    fragments = mutableListOf("fragment"),
+                    progression = 0.5,
+                    position = 42,
+                    totalProgression = 0.2,
+                    otherLocations = mutableMapOf("other" to "location")
+                ),
+                text = Locator.Text.Builder(
+                    before = "before",
+                    highlight = "highlight",
+                    after = "after"
+                )
+            )
+            .merge(Locator(href = "merged-file.html", type = "merged-text/html"))
+            .build()
+        )
+    }
+
+    @Test fun `merge a full Locator into a builder`() {
+        assertEquals(
+            Locator(
+                href = "merged-file.html",
+                type = "merged-text/html",
+                title = "Merged Title",
+                locations = Locator.Locations(
+                    fragments = listOf("merged-fragment", "fragment"),
+                    progression = 0.9,
+                    position = 23,
+                    totalProgression = 0.1,
+                    otherLocations = mapOf("fixed" to "location", "other" to "merged-location", "add" to "location")
+                ),
+                text = Locator.Text(
+                    before = "merged-before",
+                    highlight = "merged-highlight",
+                    after = null
+                )
+            ),
+            Locator.Builder(
+                href = "file.html",
+                type = "text/html",
+                title = "Title",
+                locations = Locator.Locations.Builder(
+                    fragments = mutableListOf("fragment"),
+                    progression = 0.5,
+                    position = 42,
+                    totalProgression = 0.2,
+                    otherLocations = mutableMapOf("fixed" to "location", "other" to "location")
+                ),
+                text = Locator.Text.Builder(
+                    before = "before",
+                    highlight = "highlight",
+                    after = "after"
+                )
+            )
+            .merge(Locator(
+                href = "merged-file.html",
+                type = "merged-text/html",
+                title = "Merged Title",
+                locations = Locator.Locations(
+                    fragments = listOf("merged-fragment"),
+                    progression = 0.9,
+                    position = 23,
+                    totalProgression = 0.1,
+                    otherLocations = mapOf("other" to "merged-location", "add" to "location")
+                ),
+                text = Locator.Text(
+                    before = "merged-before",
+                    highlight = "merged-highlight",
+                    after = null
+                )
+            ))
+            .build()
+        )
+    }
 }

--- a/test-app/src/main/java/org/readium/r2/testapp/bookshelf/BookRepository.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/bookshelf/BookRepository.kt
@@ -61,7 +61,7 @@ class BookRepository(private val booksDao: BooksDao) {
         return booksDao.insertBookmark(bookmark)
     }
 
-    fun bookmarksForBook(bookId: Long): LiveData<MutableList<Bookmark>> =
+    fun bookmarksForBook(bookId: Long): LiveData<List<Bookmark>> =
         booksDao.getBookmarksForBook(bookId)
 
     suspend fun deleteBookmark(bookmarkId: Long) = booksDao.deleteBookmark(bookmarkId)

--- a/test-app/src/main/java/org/readium/r2/testapp/db/BooksDao.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/db/BooksDao.kt
@@ -55,7 +55,7 @@ interface BooksDao {
      * @return List of bookmarks for the book as LiveData
      */
     @Query("SELECT * FROM " + Bookmark.TABLE_NAME + " WHERE " + Bookmark.BOOK_ID + " = :bookId")
-    fun getBookmarksForBook(bookId: Long): LiveData<MutableList<Bookmark>>
+    fun getBookmarksForBook(bookId: Long): LiveData<List<Bookmark>>
 
     /**
      * Retrieve all highlights for a specific book

--- a/test-app/src/main/java/org/readium/r2/testapp/outline/BookmarksFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/outline/BookmarksFragment.kt
@@ -60,16 +60,15 @@ class BookmarksFragment : Fragment() {
 
         bookmarkAdapter = BookmarkAdapter(publication, onBookmarkDeleteRequested = { bookmark -> viewModel.deleteBookmark(bookmark.id!!) }, onBookmarkSelectedRequested = { bookmark -> onBookmarkSelected(bookmark) })
         binding.listView.apply {
-            setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireContext())
             adapter = bookmarkAdapter
         }
 
         val comparator: Comparator<Bookmark> = compareBy({ it.resourceIndex }, { it.locator.locations.progression })
-        viewModel.getBookmarks().observe(viewLifecycleOwner, {
-            val bookmarks = it.sortedWith(comparator).toMutableList()
+        viewModel.getBookmarks().observe(viewLifecycleOwner) {
+            val bookmarks = it.sortedWith(comparator)
             bookmarkAdapter.submitList(bookmarks)
-        })
+        }
     }
 
     private fun onBookmarkSelected(bookmark: Bookmark) {
@@ -82,10 +81,6 @@ class BookmarksFragment : Fragment() {
 
 class BookmarkAdapter(private val publication: Publication, private val onBookmarkDeleteRequested: (Bookmark) -> Unit, private val onBookmarkSelectedRequested: (Bookmark) -> Unit) :
         ListAdapter<Bookmark, BookmarkAdapter.ViewHolder>(BookmarksDiff()) {
-
-    init {
-        setHasStableIds(true)
-    }
 
     override fun onCreateViewHolder(
             parent: ViewGroup,

--- a/test-app/src/main/java/org/readium/r2/testapp/outline/HighlightsFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/outline/HighlightsFragment.kt
@@ -61,7 +61,6 @@ class HighlightsFragment : Fragment() {
 
         highlightAdapter = HighlightAdapter(publication, onDeleteHighlightRequested = { highlight -> viewModel.deleteHighlight(highlight.id) }, onHighlightSelectedRequested = { highlight -> onHighlightSelected(highlight) })
         binding.listView.apply {
-            setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireContext())
             adapter = highlightAdapter
         }
@@ -83,10 +82,6 @@ class HighlightAdapter(private val publication: Publication,
                        private val onDeleteHighlightRequested: (Highlight) -> Unit,
                        private val onHighlightSelectedRequested: (Highlight) -> Unit) :
         ListAdapter<Highlight, HighlightAdapter.ViewHolder>(HighlightsDiff()) {
-
-    init {
-        setHasStableIds(true)
-    }
 
     override fun onCreateViewHolder(
             parent: ViewGroup,

--- a/test-app/src/main/java/org/readium/r2/testapp/outline/NavigationFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/outline/NavigationFragment.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.*
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.toLocator
 import org.readium.r2.testapp.databinding.FragmentListviewBinding
 import org.readium.r2.testapp.databinding.ItemRecycleNavigationBinding
 import org.readium.r2.testapp.reader.ReaderViewModel
@@ -69,7 +68,6 @@ class NavigationFragment : Fragment() {
         }
 
         binding.listView.apply {
-            setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireContext())
             adapter = navAdapter
             addItemDecoration(
@@ -106,10 +104,6 @@ class NavigationFragment : Fragment() {
 
 class NavigationAdapter(private val onLinkSelected: (Link) -> Unit) :
         ListAdapter<Pair<Int, Link>, NavigationAdapter.ViewHolder>(NavigationDiff()) {
-
-    init {
-        setHasStableIds(true)
-    }
 
     override fun onCreateViewHolder(
             parent: ViewGroup,


### PR DESCRIPTION
* Fix #93 

The EPUB `currentLocator` was not updated if the `publication.positions` was missing, which is the case by default for WebPubs.

Also added a `Locator.Builder` object to simplify progressively constructing a `Locator`.