### PR TITLE
Fix caching with `TransformingResource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
-### Streamer
+### Changed
 
-#### Fixed
+#### Shared
+
+* `TransformingResource` now caches its content by default, as it is the correct behavior in most cases. Set `cacheBytes = false` explicitly to revert to the previous behavior.
+
+### Fixed
+
+#### Streamer
 
 * Fixed parsing the table of contents of an EPUB 3 using NCX instead of a Navigation Document.
 

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpDecryptor.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpDecryptor.kt
@@ -54,7 +54,7 @@ internal class LcpDecryptor(val license: LcpLicense?) {
     private class FullLcpResource(
         resource: Resource,
         private val license: LcpLicense
-    ) : TransformingResource(resource, cacheBytes = true) {
+    ) : TransformingResource(resource) {
 
         override suspend fun transform(data: ResourceTry<ByteArray>): ResourceTry<ByteArray> =
             license.decryptFully(data, resource.link().isDeflated)

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -42,7 +42,7 @@ internal class HtmlInjector(
     private suspend fun inject(resource: Resource): Resource = object : TransformingResource(resource) {
 
         override suspend fun transform(data: ResourceTry<ByteArray>): ResourceTry<ByteArray> =
-            resource.read().mapCatching {
+            data.map {
                 val trimmedText = it.toString(link().mediaType.charset ?: Charsets.UTF_8).trim()
                 val res = if (publication.metadata.presentation.layoutOf(link()) == EpubLayout.REFLOWABLE)
                     injectReflowableHtml(trimmedText)

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubDeobfuscator.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubDeobfuscator.kt
@@ -16,7 +16,7 @@ internal class EpubDeobfuscator(private val pubId: String) {
 
     fun transform(resource: Resource): Resource = DeobfuscatingResource(resource)
 
-    inner class DeobfuscatingResource(resource: Resource): TransformingResource(resource, cacheBytes = true) {
+    inner class DeobfuscatingResource(resource: Resource): TransformingResource(resource) {
 
         override suspend fun transform(data: ResourceTry<ByteArray>): ResourceTry<ByteArray> =
             data.map { bytes ->


### PR DESCRIPTION
### Changed

#### Shared

* `TransformingResource` now caches its content by default, as it is the correct behavior in most cases. Set `cacheBytes = false` explicitly to revert to the previous behavior.

---

This fixes an issue with duplicated fetches when serving a packaged WebPub in the server.
See for more context the bug report: https://readium.slack.com/archives/C703MSTQU/p1652257069782699?thread_ts=1650958628.109609&cid=C703MSTQU 