### PR TITLE
Upgrade dependencies and Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.application") version "7.1.3" apply false
-    id("com.android.library") version "7.1.3" apply false
+    id("com.android.application") version "7.2.1" apply false
+    id("com.android.library") version "7.2.1" apply false
     id("org.jetbrains.kotlin.android") version "1.6.21" apply false
     id("org.jetbrains.dokka") version "1.6.20" apply true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,10 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.application") apply false
-    id("com.android.library") apply false
-    id("org.jetbrains.kotlin.android") apply false
-    id("org.jetbrains.dokka") apply true
+    id("com.android.application") version "7.1.3" apply false
+    id("com.android.library") version "7.1.3" apply false
+    id("org.jetbrains.kotlin.android") version "1.6.21" apply false
+    id("org.jetbrains.dokka") version "1.6.20" apply true
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,10 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.application") version "7.2.1" apply false
-    id("com.android.library") version "7.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.6.21" apply false
-    id("org.jetbrains.dokka") version "1.6.20" apply true
+    id("com.android.application") apply false
+    id("com.android.library") apply false
+    id("org.jetbrains.kotlin.android") apply false
+    id("org.jetbrains.dokka") apply true
 }
 
 subprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -55,13 +55,13 @@ afterEvaluate {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
     api(project(":readium:shared"))
 
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.core:core-ktx:1.7.0")
-    implementation("com.google.android.material:material:1.5.0")
+    implementation("com.google.android.material:material:1.6.0")
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("com.mcxiaoke.koi:async:0.5.5") {
         exclude(module = "support-v4")

--- a/readium/navigator-media2/build.gradle.kts
+++ b/readium/navigator-media2/build.gradle.kts
@@ -61,8 +61,8 @@ dependencies {
     api(project(":readium:shared"))
     api(project(":readium:navigator"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
     implementation("com.jakewharton.timber:timber:5.0.1")
 

--- a/readium/navigator/build.gradle.kts
+++ b/readium/navigator/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
 }
 
 android {
-    // FIXME: This doesn't pass the lint because some resources don"t start with r2_ yet. We need to rename all resources for the next major version.
-//    resourcePrefix "r2_"
+    // FIXME: This doesn't pass the lint because some resources don't start with readium_ yet. We need to rename all resources for the next major version.
+//    resourcePrefix "readium_"
 
     compileSdk = 32
 
@@ -64,7 +64,7 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.4.0")
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.browser:browser:1.4.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.core:core-ktx:1.7.0")
     implementation("androidx.fragment:fragment-ktx:1.4.1")
     implementation("androidx.legacy:legacy-support-core-ui:1.0.0")
@@ -92,15 +92,15 @@ dependencies {
     api("com.google.android.exoplayer:extension-mediasession:2.17.1")
     api("com.google.android.exoplayer:extension-media2:2.17.1")
     api("com.google.android.exoplayer:extension-workmanager:2.17.1")
-    implementation("com.google.android.material:material:1.5.0")
+    implementation("com.google.android.material:material:1.6.0")
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("com.shopgun.android:utils:1.0.9")
     implementation("joda-time:joda-time:2.10.14")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
     // AM NOTE: needs to stay this version for now (June 24,2020)
     //noinspection GradleDependency
-    implementation("org.jsoup:jsoup:1.14.3")
+    implementation("org.jsoup:jsoup:1.15.1")
 
     // Tests
     testImplementation("junit:junit:4.13.2")

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.json.JSONObject
 import org.jsoup.Jsoup
-import org.jsoup.safety.Whitelist
+import org.jsoup.safety.Safelist
 import org.readium.r2.navigator.extensions.optRectF
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.optNullableString
@@ -323,7 +323,7 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
             ?.first()?.html()
             ?: return false
 
-        val safe = Jsoup.clean(aside, Whitelist.relaxed())
+        val safe = Jsoup.clean(aside, Safelist.relaxed())
 
         // Initialize a new instance of LayoutInflater service
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater

--- a/readium/opds/build.gradle.kts
+++ b/readium/opds/build.gradle.kts
@@ -57,11 +57,11 @@ dependencies {
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("joda-time:joda-time:2.10.14")
     implementation("nl.komponents.kovenant:kovenant:3.3.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
     // Tests
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.7.3")
+    testImplementation("org.robolectric:robolectric:4.8.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/readium/shared/build.gradle.kts
+++ b/readium/shared/build.gradle.kts
@@ -68,15 +68,15 @@ dependencies {
     implementation("nl.komponents.kovenant:kovenant-jvm:3.3.0")
     implementation("nl.komponents.kovenant:kovenant:3.3.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.21")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
-    implementation("org.jsoup:jsoup:1.14.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
+    implementation("org.jsoup:jsoup:1.15.1")
 
     // Tests
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:3.23.1")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.6.21")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1")
-    testImplementation("org.robolectric:robolectric:4.7.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.2")
+    testImplementation("org.robolectric:robolectric:4.8.1")
 
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")

--- a/readium/streamer/build.gradle.kts
+++ b/readium/streamer/build.gradle.kts
@@ -76,12 +76,12 @@ dependencies {
         exclude(module = "support-v4")
     }
     implementation("joda-time:joda-time:2.10.14")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
     // Tests
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.robolectric:robolectric:4.7.3")
+    testImplementation("org.assertj:assertj-core:3.23.1")
+    testImplementation("org.robolectric:robolectric:4.8.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,16 @@ pluginManagement {
         maven(url = "https://jitpack.io")
         maven(url = "https://s3.amazonaws.com/repo.commonsware.com")
     }
+
+    // Setting the plugin versions here doesn't work with AGP Upgrade Assistant, but we need
+    // it to integrate Readium in submodules.
+    // See https://github.com/readium/kotlin-toolkit/pull/97
+    plugins {
+        id("com.android.application") version ("7.2.1")
+        id("com.android.library") version ("7.2.1")
+        id("org.jetbrains.kotlin.android") version ("1.6.21")
+        id("org.jetbrains.dokka") version ("1.6.20")
+    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,13 +17,6 @@ pluginManagement {
         maven(url = "https://jitpack.io")
         maven(url = "https://s3.amazonaws.com/repo.commonsware.com")
     }
-
-    plugins {
-        id("com.android.application") version ("7.1.3")
-        id("com.android.library") version ("7.1.3")
-        id("org.jetbrains.kotlin.android") version ("1.6.21")
-        id("org.jetbrains.dokka") version ("1.6.20")
-    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.browser:browser:1.4.0")
     implementation("androidx.cardview:cardview:1.0.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.fragment:fragment-ktx:1.4.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.4.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.1")
@@ -93,14 +93,14 @@ dependencies {
     implementation("com.github.edrlab.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT") {
         exclude(group = "org.parboiled")
     }
-    implementation("com.google.android.material:material:1.5.0")
+    implementation("com.google.android.material:material:1.6.0")
     implementation("com.jakewharton.timber:timber:5.0.1")
     // AM NOTE: needs to stay this version for now (June 24,2020)
     implementation("com.squareup.picasso:picasso:2.71828")
     implementation("joda-time:joda-time:2.10.14")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
     // AM NOTE: needs to stay this version for now (June 24,2020)
-    implementation("org.jsoup:jsoup:1.14.3")
+    implementation("org.jsoup:jsoup:1.15.1")
 
     implementation("androidx.media2:media2-session:1.2.1")
     implementation("androidx.media2:media2-player:1.2.1")


### PR DESCRIPTION
EDIT: The following is outdated, I forgot about this other issue:
 
* https://github.com/readium/kotlin-toolkit/pull/97

---

I moved the Gradle plugin versions from the [`settings.gradle.kts`'s `pluginManagement` section](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_version_management) to the [root `build.gradle.kts` file](https://developer.android.com/studio/releases/gradle-plugin#updating-plugin) instead. The [AGP Upgrade Assistant](https://developer.android.com/studio/build/agp-upgrade-assistant) was not working with `settings.gradle.kts` and having the versions in the root `build.gradle.kts` seems to be enough:

>You can specify the plugin version in either the File > Project Structure > Project menu in Android Studio, or the top-level build.gradle file. The plugin version applies to all modules built in that Android Studio project.
> https://developer.android.com/studio/releases/gradle-plugin#updating-plugin