### PR TITLE
Fix code highlighting in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ lint/reports/
 docs/readium
 docs/index.md
 docs/package-list
+site/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ tasks.register("clean", Delete::class).configure {
 }
 
 tasks.register("cleanDocs", Delete::class).configure {
-    delete("${project.rootDir}/docs/readium", "${project.rootDir}/docs/index.md")
+    delete("${project.rootDir}/docs/readium", "${project.rootDir}/docs/index.md", "${project.rootDir}/site")
 }
 
 tasks.withType<DokkaTaskPartial>().configureEach {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_name: kotlin-toolkit
 repo_url: https://github.com/readium/kotlin-toolkit
 
 # Copyright (shown at the footer)
-copyright: 'Copyright &copy; 2021 Readium Foundation'
+copyright: 'Copyright &copy; 2022 Readium Foundation'
 
 # Material theme
 theme:
@@ -30,13 +30,13 @@ markdown_extensions:
   - def_list
   - toc:
       permalink: true
-#  - pymdownx.betterem:
-#      smart_enable: all
-#  - pymdownx.caret
-#  - pymdownx.inlinehilite
-#  - pymdownx.magiclink
-#  - pymdownx.smartsymbols
-#  - pymdownx.superfences
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
 
 # Dev server binding
 #dev_addr: 127.0.0.1:3001


### PR DESCRIPTION
On the documentation website, code blocks are not being highlighted.  This PR fixes that by uncommenting the `markdown_extensions` in `mkdocs.yml`.  In addition, I also added the `site/` directory to gitignore and to the `cleanDocs` gradle script, and changed the copyright year for mkdocs to 2022.