### PR TITLE
Navigator: Fix `currentLocator` with FXL and prevent unnecessary refreshes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * [swift-toolkit#61](https://github.com/readium/swift-toolkit/issues/61) Fixed serving EPUB resources when the HREF contains an anchor or query parameters.
+* Fixed emitting `currentLocator` with fixed layout EPUBs.
+* Prevent refreshing an already loaded EPUB resource when jumping to a `Locator` in it.
 
 
 ## [2.2.0]

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -32,12 +32,12 @@ import org.json.JSONObject
 import org.readium.r2.navigator.*
 import org.readium.r2.navigator.databinding.ActivityR2ViewpagerBinding
 import org.readium.r2.navigator.epub.EpubNavigatorViewModel.RunScriptCommand
-import org.readium.r2.navigator.extensions.htmlId
 import org.readium.r2.navigator.extensions.optRectF
 import org.readium.r2.navigator.extensions.positionsByResource
 import org.readium.r2.navigator.extensions.withBaseUrl
 import org.readium.r2.navigator.html.HtmlDecorationTemplates
 import org.readium.r2.navigator.pager.R2EpubPageFragment
+import org.readium.r2.navigator.pager.R2FXLPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.navigator.pager.R2PagerAdapter.PageResource
 import org.readium.r2.navigator.pager.R2ViewPager
@@ -46,7 +46,10 @@ import org.readium.r2.shared.COLUMN_COUNT_REF
 import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.extensions.addPrefix
 import org.readium.r2.shared.extensions.tryOrLog
-import org.readium.r2.shared.publication.*
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.ReadingProgression
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.presentation
 import org.readium.r2.shared.publication.services.isRestricted
@@ -68,7 +71,7 @@ typealias JavascriptInterfaceFactory = (resource: Link) -> Any?
  *
  * To use this [Fragment], create a factory with `EpubNavigatorFragment.createFactory()`.
  */
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalDecorator::class)
+@OptIn(ExperimentalDecorator::class)
 class EpubNavigatorFragment private constructor(
     override val publication: Publication,
     private val baseUrl: String,
@@ -125,9 +128,11 @@ class EpubNavigatorFragment private constructor(
 
     /**
      * Evaluates the given JavaScript on the currently visible HTML resource.
+     *
+     * Note that this only work with reflowable resources.
      */
     suspend fun evaluateJavascript(script: String): String? {
-        val page = currentFragment ?: return null
+        val page = currentReflowablePageFragment ?: return null
         page.awaitLoaded()
         val webView = page.webView ?: return null
         return webView.runJavaScriptSuspend(script)
@@ -260,22 +265,22 @@ class EpubNavigatorFragment private constructor(
 //                if (publication.metadata.presentation.layout == EpubLayout.REFLOWABLE) {
 //                    resourcePager.disableTouchEvents = true
 //                }
-                if (preferences.getBoolean(SCROLL_REF, false)) {
-                    if (currentPagerPosition < position) {
-                        // handle swipe LEFT
-                        currentFragment?.webView?.scrollToStart()
-                    } else if (currentPagerPosition > position) {
-                        // handle swipe RIGHT
-                        currentFragment?.webView?.scrollToEnd()
-                    }
-                } else {
-                    if (currentPagerPosition < position) {
-                        // handle swipe LEFT
-                        currentFragment?.webView?.setCurrentItem(0, false)
-                    } else if (currentPagerPosition > position) {
-                        // handle swipe RIGHT
-                        currentFragment?.webView?.apply {
-                            setCurrentItem(numPages - 1, false)
+                currentReflowablePageFragment?.webView?.let { webView ->
+                    if (preferences.getBoolean(SCROLL_REF, false)) {
+                        if (currentPagerPosition < position) {
+                            // handle swipe LEFT
+                            webView.scrollToStart()
+                        } else if (currentPagerPosition > position) {
+                            // handle swipe RIGHT
+                            webView.scrollToEnd()
+                        }
+                    } else {
+                        if (currentPagerPosition < position) {
+                            // handle swipe LEFT
+                            webView.setCurrentItem(0, false)
+                        } else if (currentPagerPosition > position) {
+                            // handle swipe RIGHT
+                            webView.setCurrentItem(webView.numPages - 1, false)
                         }
                     }
                 }
@@ -329,20 +334,16 @@ class EpubNavigatorFragment private constructor(
             val (index, resource) = page
 
             if (resourcePager.currentItem != index) {
-                resourcePager.currentItem = index
-            } else if (resource is PageResource.EpubReflowable) {
-                var url = resource.url
-                locator.locations.htmlId?.let { htmlId ->
-                    url += htmlId.addPrefix("#")
+                if (resource is PageResource.EpubReflowable) {
+                    pendingLocator = locator
                 }
-                currentFragment?.webView?.loadUrl(url)
+                resourcePager.currentItem = index
             }
+
+            currentReflowablePageFragment?.loadLocator(locator)
         }
 
-        resourcePager.adapter = adapter
-
         if (publication.metadata.presentation.layout != EpubLayout.FIXED) {
-            pendingLocator = locator
             setCurrent(resourcesSingle)
         } else {
 
@@ -376,7 +377,7 @@ class EpubNavigatorFragment private constructor(
     private fun run(command: RunScriptCommand) {
         when (command.scope) {
             RunScriptCommand.Scope.CurrentResource -> {
-                currentFragment?.webView
+                currentReflowablePageFragment?.webView
                     ?.runJavaScript(command.script)
             }
             RunScriptCommand.Scope.LoadedResources -> {
@@ -398,7 +399,7 @@ class EpubNavigatorFragment private constructor(
     // SelectableNavigator
 
     override suspend fun currentSelection(): Selection? {
-        val webView = currentFragment?.webView ?: return null
+        val webView = currentReflowablePageFragment?.webView ?: return null
         val json =
             webView.runJavaScriptSuspend("readium.getCurrentSelection();")
                 .takeIf { it != "null"}
@@ -421,12 +422,12 @@ class EpubNavigatorFragment private constructor(
     }
 
     private fun PointF.adjustedToViewport(): PointF =
-        currentFragment?.paddingTop?.let { top ->
+        currentReflowablePageFragment?.paddingTop?.let { top ->
             PointF(x, y + top)
         } ?: this
 
     private fun RectF.adjustedToViewport(): RectF =
-        currentFragment?.paddingTop?.let { topOffset ->
+        currentReflowablePageFragment?.paddingTop?.let { topOffset ->
             RectF(left, top + topOffset, right, bottom)
         } ?: this
 
@@ -573,7 +574,7 @@ class EpubNavigatorFragment private constructor(
             return goToNextResource(animated, completion)
         }
 
-        val webView = currentFragment?.webView ?: return false
+        val webView = currentReflowablePageFragment?.webView ?: return false
 
         when (readingProgression) {
             ReadingProgression.LTR, ReadingProgression.TTB, ReadingProgression.AUTO ->
@@ -591,7 +592,7 @@ class EpubNavigatorFragment private constructor(
             return goToPreviousResource(animated, completion)
         }
 
-        val webView = currentFragment?.webView ?: return false
+        val webView = currentReflowablePageFragment?.webView ?: return false
 
         when (readingProgression) {
             ReadingProgression.LTR, ReadingProgression.TTB, ReadingProgression.AUTO ->
@@ -612,15 +613,11 @@ class EpubNavigatorFragment private constructor(
 
         resourcePager.setCurrentItem(resourcePager.currentItem + 1, animated)
 
-        if (publication.metadata.effectiveReadingProgression == ReadingProgression.RTL) {
-            // The view has RTL layout
-            currentFragment?.webView?.apply {
-                setCurrentItem(numPages - 1, false)
-            }
-        } else {
-            // The view has LTR layout
-            currentFragment?.webView?.apply {
-                setCurrentItem(0, false)
+        currentReflowablePageFragment?.webView?.let { webView ->
+            if (publication.metadata.effectiveReadingProgression == ReadingProgression.RTL) {
+                webView.setCurrentItem(webView.numPages - 1, false)
+            } else {
+                webView.setCurrentItem(0, false)
             }
         }
 
@@ -635,15 +632,11 @@ class EpubNavigatorFragment private constructor(
 
         resourcePager.setCurrentItem(resourcePager.currentItem - 1, animated)
 
-        if (publication.metadata.effectiveReadingProgression == ReadingProgression.RTL) {
-            // The view has RTL layout
-            currentFragment?.webView?.apply {
-                setCurrentItem(0, false)
-            }
-        } else {
-            // The view has LTR layout
-            currentFragment?.webView?.apply {
-                setCurrentItem(numPages - 1, false)
+        currentReflowablePageFragment?.webView?.let { webView ->
+            if (publication.metadata.effectiveReadingProgression == ReadingProgression.RTL) {
+                webView.setCurrentItem(0, false)
+            } else {
+                webView.setCurrentItem(webView.numPages - 1, false)
             }
         }
 
@@ -655,10 +648,13 @@ class EpubNavigatorFragment private constructor(
         get() = if (::resourcePager.isInitialized) resourcePager.adapter as? R2PagerAdapter
             else null
 
-    private val currentFragment: R2EpubPageFragment? get() =
+    private val currentFragment: Fragment? get() =
         r2PagerAdapter?.let { adapter ->
-            adapter.mFragments.get(adapter.getItemId(resourcePager.currentItem)) as? R2EpubPageFragment
+            adapter.mFragments.get(adapter.getItemId(resourcePager.currentItem))
         }
+
+    private val currentReflowablePageFragment: R2EpubPageFragment? get() =
+        currentFragment as? R2EpubPageFragment
 
     /**
      * Returns the reflowable page fragment matching the given href, if it is already loaded in the
@@ -721,17 +717,17 @@ class EpubNavigatorFragment private constructor(
         debounceLocationNotificationJob = launch {
             delay(100L)
 
-            val webView = currentFragment?.webView
-            if (pendingLocator != null || webView == null) {
+            val reflowableWebView = currentReflowablePageFragment?.webView
+            if (pendingLocator != null) {
                 return@launch
             }
 
             // The transition has stabilized, so we can ask the web view to refresh its current
             // item to reflect the current scroll position.
-            webView.updateCurrentItem()
+            reflowableWebView?.updateCurrentItem()
 
             val resource = publication.readingOrder[resourcePager.currentItem]
-            val progression = webView.progression.coerceIn(0.0, 1.0)
+            val progression = reflowableWebView?.progression?.coerceIn(0.0, 1.0) ?: 0.0
 
             val positionLocator = publication.positionsByResource[resource.href]?.let { positions ->
                 val index = ceil(progression * (positions.size - 1)).toInt()
@@ -752,11 +748,13 @@ class EpubNavigatorFragment private constructor(
 
             // Deprecated notifications
             navigatorDelegate?.locationDidChange(navigator = navigator, locator = currentLocator)
-            paginationListener?.onPageChanged(
-                pageIndex = webView.mCurItem,
-                totalPages = webView.numPages,
-                locator = currentLocator
-            )
+            reflowableWebView?.let {
+                paginationListener?.onPageChanged(
+                    pageIndex = it.mCurItem,
+                    totalPages = it.numPages,
+                    locator = currentLocator
+                )
+            }
         }
     }
 


### PR DESCRIPTION
### Fixed
#### Navigator

* Fixed emitting `currentLocator` with fixed layout EPUBs.
* Prevent refreshing an already loaded EPUB resource when jumping to a `Locator` in it.
