### PR TITLE
Licenses : Add Accept header on fetch status document request

### DIFF
--- a/readium/lcp/src/main/java/org/readium/r2/lcp/license/License.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/license/License.kt
@@ -192,7 +192,7 @@ internal class License(
                 license.url(LicenseDocument.Rel.status, preferredType = MediaType.LCP_STATUS_DOCUMENT)
             } ?: throw LcpException.LicenseInteractionNotAvailable
 
-            return network.fetch(statusURL.toString()).getOrThrow()
+            return network.fetch(statusURL.toString(), headers = mapOf("Accept" to "application/json")).getOrThrow()
         }
 
         try {

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/license/License.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/license/License.kt
@@ -192,7 +192,7 @@ internal class License(
                 license.url(LicenseDocument.Rel.status, preferredType = MediaType.LCP_STATUS_DOCUMENT)
             } ?: throw LcpException.LicenseInteractionNotAvailable
 
-            return network.fetch(statusURL.toString(), headers = mapOf("Accept" to "application/json")).getOrThrow()
+            return network.fetch(statusURL.toString(), headers = mapOf("Accept" to MediaType.LCP_STATUS_DOCUMENT.toString())).getOrThrow()
         }
 
         try {

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
@@ -315,7 +315,7 @@ internal class LicenseValidation(
     private suspend fun fetchStatus(license: LicenseDocument) {
         val url = license.url(LicenseDocument.Rel.status, preferredType = MediaType.LCP_STATUS_DOCUMENT).toString()
         // Short timeout to avoid blocking the License, since the LSD is optional.
-        val data = network.fetch(url, timeout = 5.seconds)
+        val data = network.fetch(url, timeout = 5.seconds, headers = mapOf("Accept" to "application/json"))
             .getOrElse { throw LcpException.Network(it) }
 
         raise(Event.retrievedStatusData(data))

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
@@ -315,7 +315,7 @@ internal class LicenseValidation(
     private suspend fun fetchStatus(license: LicenseDocument) {
         val url = license.url(LicenseDocument.Rel.status, preferredType = MediaType.LCP_STATUS_DOCUMENT).toString()
         // Short timeout to avoid blocking the License, since the LSD is optional.
-        val data = network.fetch(url, timeout = 5.seconds, headers = mapOf("Accept" to "application/json"))
+        val data = network.fetch(url, timeout = 5.seconds, headers = mapOf("Accept" to MediaType.LCP_STATUS_DOCUMENT.toString()))
             .getOrElse { throw LcpException.Network(it) }
 
         raise(Event.retrievedStatusData(data))

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/NetworkService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/NetworkService.kt
@@ -41,7 +41,7 @@ internal class NetworkService {
         }
     }
 
-    suspend fun fetch(url: String, method: Method = Method.GET, parameters: URLParameters = emptyMap(), timeout: Duration? = null): Try<ByteArray, NetworkException> =
+    suspend fun fetch(url: String, method: Method = Method.GET, parameters: URLParameters = emptyMap(), timeout: Duration? = null, headers: Map<String, String> = emptyMap()): Try<ByteArray, NetworkException> =
         withContext(Dispatchers.IO) {
             try {
                 @Suppress("NAME_SHADOWING")
@@ -52,6 +52,7 @@ internal class NetworkService {
                 if (timeout != null) {
                     connection.connectTimeout = timeout.inWholeMilliseconds.toInt()
                 }
+                connection.appendRequestHeaders(headers)
 
                 val status = connection.responseCode
                 if (status >= 400) {
@@ -62,6 +63,13 @@ internal class NetworkService {
             } catch (e: Exception) {
                 Timber.e(e)
                 Try.failure(NetworkException(status = null, cause = e))
+            }
+        }
+
+    private fun HttpURLConnection.appendRequestHeaders(headers: Map<String, String>): HttpURLConnection =
+        apply {
+            for ((key, value) in headers) {
+                this.setRequestProperty(key, value)
             }
         }
 

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/NetworkService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/NetworkService.kt
@@ -69,7 +69,7 @@ internal class NetworkService {
     private fun HttpURLConnection.appendRequestHeaders(headers: Map<String, String>): HttpURLConnection =
         apply {
             for ((key, value) in headers) {
-                this.setRequestProperty(key, value)
+                setRequestProperty(key, value)
             }
         }
 


### PR DESCRIPTION
# Licenses : Add Accept header on fetch status document request


### Fixed

I added an `Accept` header on status document request, since some servers requires this header to accept this request.
`Accept` is now set to `application/json` since it's a json document.