### PR TITLE
Remove the standardebooks.org OPDS catalog

### DIFF
--- a/test-app/src/main/java/org/readium/r2/testapp/catalogs/CatalogFeedListFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/catalogs/CatalogFeedListFragment.kt
@@ -84,15 +84,9 @@ class CatalogFeedListFragment : Fragment() {
                 href = "http://open.minitex.org/textbooks/",
                 type = 1
             )
-            val sEBCatalog = Catalog(
-                title = "Standard eBooks Catalog",
-                href = "https://standardebooks.org/opds/all",
-                type = 1
-            )
 
             catalogFeedListViewModel.insertCatalog(oPDS2Catalog)
             catalogFeedListViewModel.insertCatalog(oTBCatalog)
-            catalogFeedListViewModel.insertCatalog(sEBCatalog)
         }
 
         binding.catalogFeedAddCatalogFab.setOnClickListener {


### PR DESCRIPTION
They now require a paid donation to access their catalog.