### PR TITLE
Support for unsafe HTTP redirections with `HttpDefaultClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file. Take a look
 #### Shared
 
 * Extract the raw content (text, images, etc.) of a publication. [Take a look at the user guide](docs/guides/content.md).
+* Add support for unsafe HTTP redirections with `HttpDefaultClient`.
+    * You will need to opt-in explicitly by implementing `HttpDefaultClient.Callback.onFollowUnsafeRedirect`.
 
 #### Navigator
 


### PR DESCRIPTION
## Changelog

### Added

#### Shared

 * Add support for unsafe HTTP redirections with `HttpDefaultClient`.
    * You will need to opt-in explicitly by implementing `HttpDefaultClient.Callback.onFollowUnsafeRedirect`.

## Notes

We had a concrete case when working with the OPDS catalog from the BNF. It contains HTTP links like:

```
http://gallica.bnf.fr/ark:/12148/bpt6k6559996k.epub
```

which redirects to the HTTPS

```
https://gallica.bnf.fr/ark:/12148/bpt6k6559996k.epub
```

This failed with `HttpURLConnection` because of the scheme change.
For more information on why it's not possible by default https://stackoverflow.com/a/26046079

This PR adds a way to opt-in for explicit redirections in this case. Apps will need to opt-in as it could be unsafe for example with a `POST` or if the domain changes.