### PR TITLE
Fix EPUB footnotes pop-up

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -46,7 +46,9 @@ import org.readium.r2.navigator.pager.R2ViewPager
 import org.readium.r2.navigator.settings.*
 import org.readium.r2.navigator.util.createFragmentFactory
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.tryOrLog
+import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -686,6 +688,10 @@ class EpubNavigatorFragment private constructor(
 
         override fun shouldInterceptRequest(webView: WebView, request: WebResourceRequest): WebResourceResponse? =
             viewModel.shouldInterceptRequest(request)
+
+        override fun resourceAtUrl(url: String): Resource? =
+            viewModel.internalLinkFromUrl(url)
+                ?.let { publication.get(it) }
     }
 
     override fun goForward(animated: Boolean, completion: () -> Unit): Boolean {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -183,17 +183,25 @@ internal class EpubNavigatorViewModel(
      * Intercepts and handles web view navigation to [url].
      */
     fun navigateToUrl(url: Uri) = viewModelScope.launch {
-        var href = url.toString()
-        if (href.startsWith(baseUrl)) {
-            href = href.removePrefix(baseUrl).addPrefix("/")
-            publication.linkWithHref(href)
-                // Query parameters must be kept as they might be relevant for the fetcher.
-                ?.copy(href = href)
-                ?.let { _events.send(Event.GoTo(it)) }
-
+        val href = url.toString()
+        val link = internalLinkFromUrl(href)
+        if (link != null) {
+            _events.send(Event.GoTo(link))
         } else {
             _events.send(Event.OpenExternalLink(url))
         }
+    }
+
+    /**
+     * Gets the publication [Link] targeted by the given [url].
+     */
+    fun internalLinkFromUrl(url: String): Link? {
+        if (!url.startsWith(baseUrl)) return null
+
+        val href = url.removePrefix(baseUrl).addPrefix("/")
+        return publication.linkWithHref(href)
+            // Query parameters must be kept as they might be relevant for the fetcher.
+            ?.copy(href = href)
     }
 
     fun shouldInterceptRequest(request: WebResourceRequest): WebResourceResponse? =

--- a/readium/navigator/src/main/res/layout/popup_footnote.xml
+++ b/readium/navigator/src/main/res/layout/popup_footnote.xml
@@ -3,7 +3,7 @@
     android:id="@+id/rl_custom_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white"
+    android:background="?attr/colorSurface"
     android:padding="2dp">
 
     <ImageButton

--- a/test-app/src/main/res/values/styles.xml
+++ b/test-app/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.Light">
+    <style name="AppTheme" parent="Theme.Material3.DayNight">
 
     </style>
 


### PR DESCRIPTION
* Fix a regression in the new (lack of) EPUB server when showing footnotes. The HTML content couldn't be fetched by `JSoup` of course.
* Fix the pop-up background color when the dark theme is enabled.
* Follow the system dark theme in the test app. 