### PR TITLE
Fix FXL font size affected by device settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project will be documented in this file. Take a look
 * Prevent refreshing an already loaded EPUB resource when jumping to a `Locator` in it.
 * [#86](https://github.com/readium/kotlin-toolkit/issues/86) Fixed page swipes while selecting text in an EPUB resource.
 * The `onTap` event is not sent when an EPUB text selection is active anymore, to prevent showing the app bar while dismissing a selection.
+* [#76](https://github.com/readium/kotlin-toolkit/issues/76) Fixed EPUB fixed layout font size affected by device settings.
 
 
 ## [2.2.0]

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2FXLPageFragment.kt
@@ -127,6 +127,10 @@ class R2FXLPageFragment : Fragment() {
         webView.settings.setSupportZoom(true)
         webView.settings.builtInZoomControls = true
         webView.settings.displayZoomControls = false
+        // If we don't explicitly override the [textZoom], it will be set by Android's
+        // accessibility font size system setting which breaks the layout of some fixed layouts.
+        // See https://github.com/readium/kotlin-toolkit/issues/76
+        webView.settings.textZoom = 100
 
         webView.setInitialScale(1)
 


### PR DESCRIPTION
### Fixed

#### Navigator

* [#76](https://github.com/readium/kotlin-toolkit/issues/76) Fixed EPUB fixed layout font size affected by device settings.

---

* Fix #76 