### PR TITLE
Fix bottom tabs and publication detail in testapp

### DIFF
--- a/test-app/src/main/java/org/readium/r2/testapp/catalogs/PublicationDetailFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/catalogs/PublicationDetailFragment.kt
@@ -46,8 +46,10 @@ class PublicationDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         (activity as MainActivity).supportActionBar?.title = publication?.metadata?.title
 
-        Picasso.get().load(publication?.images?.first()?.href)
-            .into(binding.catalogDetailCoverImage)
+        if (publication?.images?.isNotEmpty() == true) {
+            Picasso.get().load(publication?.images?.first()?.href)
+                .into(binding.catalogDetailCoverImage)
+        }
 
         binding.catalogDetailDescriptionText.text = publication?.metadata?.description
         binding.catalogDetailTitleText.text = publication?.metadata?.title

--- a/test-app/src/main/java/org/readium/r2/testapp/catalogs/PublicationDetailFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/catalogs/PublicationDetailFragment.kt
@@ -46,10 +46,9 @@ class PublicationDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         (activity as MainActivity).supportActionBar?.title = publication?.metadata?.title
 
-        if (publication?.images?.isNotEmpty() == true) {
-            Picasso.get().load(publication?.images?.first()?.href)
-                .into(binding.catalogDetailCoverImage)
-        }
+        publication?.images?.firstOrNull()
+            ?.let { Picasso.get().load(it.href) }
+            ?.into(binding.catalogDetailCoverImage)
 
         binding.catalogDetailDescriptionText.text = publication?.metadata?.description
         binding.catalogDetailTitleText.text = publication?.metadata?.title

--- a/test-app/src/main/res/menu/bottom_nav_menu.xml
+++ b/test-app/src/main/res/menu/bottom_nav_menu.xml
@@ -2,17 +2,17 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/navigation_bookshelf"
+        android:id="@+id/bookshelf"
         android:icon="@drawable/baseline_local_library_24"
         android:title="@string/title_bookshelf" />
 
     <item
-        android:id="@+id/navigation_catalog_list"
+        android:id="@+id/catalogs"
         android:icon="@drawable/baseline_dashboard_24"
         android:title="@string/title_catalogs" />
 
     <item
-        android:id="@+id/navigation_about"
+        android:id="@+id/about"
         android:icon="@drawable/baseline_info_24"
         android:title="@string/title_about" />
 

--- a/test-app/src/main/res/navigation/about.xml
+++ b/test-app/src/main/res/navigation/about.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/about"
+    app:startDestination="@+id/navigation_about">
+
+    <fragment
+        android:id="@+id/navigation_about"
+        android:name="org.readium.r2.testapp.about.AboutFragment"
+        android:label="@string/title_about"
+        tools:layout="@layout/fragment_about" />
+
+</navigation>

--- a/test-app/src/main/res/navigation/bookshelf.xml
+++ b/test-app/src/main/res/navigation/bookshelf.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/bookshelf"
+    app:startDestination="@+id/navigation_bookshelf">
+
+    <fragment
+        android:id="@+id/navigation_bookshelf"
+        android:name="org.readium.r2.testapp.bookshelf.BookshelfFragment"
+        android:label="@string/title_bookshelf"
+        tools:layout="@layout/fragment_bookshelf" />
+
+</navigation>

--- a/test-app/src/main/res/navigation/catalogs.xml
+++ b/test-app/src/main/res/navigation/catalogs.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/catalogs"
+    app:startDestination="@+id/navigation_catalog_list">
+
+    <fragment
+        android:id="@+id/navigation_catalog_list"
+        android:name="org.readium.r2.testapp.catalogs.CatalogFeedListFragment"
+        android:label="@string/title_catalogs"
+        tools:layout="@layout/fragment_catalog_feed_list">
+        <action
+            android:id="@+id/action_navigation_catalog_list_to_navigation_catalog"
+            app:destination="@id/navigation_catalog" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/navigation_catalog"
+        android:name="org.readium.r2.testapp.catalogs.CatalogFragment"
+        tools:layout="@layout/fragment_catalog">
+        <action
+            android:id="@+id/action_navigation_catalog_to_navigation_catalog_detail"
+            app:destination="@id/navigation_publication_detail" />
+        <action
+            android:id="@+id/action_navigation_catalog_self"
+            app:destination="@id/navigation_catalog" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/navigation_publication_detail"
+        android:name="org.readium.r2.testapp.catalogs.PublicationDetailFragment"
+        tools:layout="@layout/fragment_publication_detail" />
+
+</navigation>

--- a/test-app/src/main/res/navigation/navigation.xml
+++ b/test-app/src/main/res/navigation/navigation.xml
@@ -1,46 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mobile_navigation"
-    app:startDestination="@+id/navigation_bookshelf">
+    app:startDestination="@+id/bookshelf">
 
-    <fragment
-        android:id="@+id/navigation_catalog_list"
-        android:name="org.readium.r2.testapp.catalogs.CatalogFeedListFragment"
-        android:label="@string/title_catalogs"
-        tools:layout="@layout/fragment_catalog_feed_list">
-        <action
-            android:id="@+id/action_navigation_catalog_list_to_navigation_catalog"
-            app:destination="@id/navigation_catalog" />
-    </fragment>
+    <include app:graph="@navigation/bookshelf" />
+    <include app:graph="@navigation/catalogs" />
+    <include app:graph="@navigation/about" />
 
-    <fragment
-        android:id="@+id/navigation_bookshelf"
-        android:name="org.readium.r2.testapp.bookshelf.BookshelfFragment"
-        android:label="@string/title_bookshelf"
-        tools:layout="@layout/fragment_bookshelf" />
-
-    <fragment
-        android:id="@+id/navigation_about"
-        android:name="org.readium.r2.testapp.about.AboutFragment"
-        android:label="@string/title_about"
-        tools:layout="@layout/fragment_about" />
-
-    <fragment
-        android:id="@+id/navigation_catalog"
-        android:name="org.readium.r2.testapp.catalogs.CatalogFragment"
-        tools:layout="@layout/fragment_catalog">
-        <action
-            android:id="@+id/action_navigation_catalog_to_navigation_catalog_detail"
-            app:destination="@id/navigation_publication_detail" />
-        <action
-            android:id="@+id/action_navigation_catalog_self"
-            app:destination="@id/navigation_catalog" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/navigation_publication_detail"
-        android:name="org.readium.r2.testapp.catalogs.PublicationDetailFragment"
-        tools:layout="@layout/fragment_publication_detail" />
 </navigation>


### PR DESCRIPTION
This PR fixes two relatively small issues with the testapp.

1. When a publication doesn't have a cover image (in the `images` array in the OPDS feed), the publication detail screen crashes.  Added a check to make sure it has an image before trying to load it
2. Under the scenario outlined below, the bottom navigation selected tab would break.  This was reproduced in a minimal repo.  The fix was to add separate nav graphs for each of the tabs, in addition to the main one.  Borrowed from https://github.com/android/architecture-components-samples/tree/master/NavigationAdvancedSample/app/src/main/res/navigation

Selected Tab Issue

1. Select the Catalogs tab
2. Select a feed to go to the catalog screen
3. Select the Bookshelf tab
4. Select the Catalogs tab

Result:  It navigates to the catalog screen from step 2, however the Bookshelf tab is still selected.