### PR TITLE
Fix integration as Git submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ This toolkit is a modular project, which follows the [Readium Architecture](http
 
 A [Test App](test-app) demonstrates how to integrate the Readium Kotlin toolkit in your own reading app.
 
-## Using Readium
-
 :question: **Find documentation and API reference at [readium.org/kotlin-toolkit](https://readium.org/kotlin-toolkit)**.
 
-Readium modules are distributed through [JitPack](https://jitpack.io/#readium/kotlin-toolkit). It's also possible to clone the repository (or a fork) and depend on the modules locally.
+## Setting Up Readium
 
-### From the JitPack Maven repository
-
-Make sure that you have the `$readium_version` property set in your root `build.gradle` and add the JitPack repository.
+Readium modules are distributed through [JitPack](https://jitpack.io/#readium/kotlin-toolkit). Make sure that you have the `$readium_version` property set in your root `build.gradle`, then add the JitPack and JCenter repositories.
 
 ```groovy
 buildscript {
@@ -32,6 +28,7 @@ buildscript {
 
 allprojects {
     repositories {
+        jcenter()
         maven { url 'https://jitpack.io' }
     }
 }
@@ -49,7 +46,7 @@ dependencies {
 }
 ```
 
-### From a local Git clone
+### Using a local Git clone
 
 You may prefer to use a local Git clone if you want to contribute to Readium, or if you are using your own fork.
 
@@ -65,36 +62,14 @@ Make sure you have Jetifier enabled in your `gradle.properties` file:
 android.enableJetifier=true
 ```
 
-Then, add the following to your project's `settings.gradle` file, altering the paths if needed. Keep only the modules you want to use.
+Then, include the Readium build to your project's `settings.gradle` file. The Readium dependencies will automatically build against the local sources.
 
 ```groovy
-include ':readium:shared'
-project(':readium:shared').projectDir = file('kotlin-toolkit/readium/shared')
-
-include ':readium:streamer'
-project(':readium:streamer').projectDir = file('kotlin-toolkit/readium/streamer')
-
-include ':readium:navigator'
-project(':readium:navigator').projectDir = file('kotlin-toolkit/readium/navigator')
-
-include ':readium:opds'
-project(':readium:opds').projectDir = file('kotlin-toolkit/readium/opds')
-
-include ':readium:lcp'
-project(':readium:lcp').projectDir = file('kotlin-toolkit/readium/lcp')
+// Provide the path to the Git submodule.
+includeBuild 'kotlin-toolkit'
 ```
 
-You should now see the Readium modules appear as part of your project. You can depend on them as you would on any other local module:
-
-```
-dependencies {
-    implementation project(':readium:shared')
-    implementation project(':readium:streamer')
-    implementation project(':readium:navigator')
-    implementation project(':readium:opds')
-    implementation project(':readium:lcp')
-}
-```
+:warning: When importing Readium locally, you will need to use the same version of the Android Gradle Plugin in your project.
 
 ### Building with Readium LCP
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ First, add the repository as a Git submodule of your app repository, then checko
 git submodule add https://github.com/readium/kotlin-toolkit.git
 ```
 
+Make sure you have Jetifier enabled in your `gradle.properties` file:
+
+```properties
+android.enableJetifier=true
+```
+
 Then, add the following to your project's `settings.gradle` file, altering the paths if needed. Keep only the modules you want to use.
 
 ```groovy

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ A [Test App](test-app) demonstrates how to integrate the Readium Kotlin toolkit 
 
 :question: **Find documentation and API reference at [readium.org/kotlin-toolkit](https://readium.org/kotlin-toolkit)**.
 
+## Minimum Requirements
+
+| Readium | Android min SDK | Android compile SDK | Kotlin compiler | Gradle |
+|---------|-----------------|---------------------|-----------------|--------|
+| latest  | 21              | 33                  | 1.7.10          | 6.9.3  |
+
 ## Setting Up Readium
 
 Readium modules are distributed through [JitPack](https://jitpack.io/#readium/kotlin-toolkit). Make sure that you have the `$readium_version` property set in your root `build.gradle`, then add the JitPack and JCenter repositories.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,10 @@ plugins {
     id("org.jetbrains.dokka") apply true
 }
 
+allprojects {
+    group = "com.github.readium.kotlin-toolkit"
+}
+
 subprojects {
     tasks.register<Jar>("javadocsJar") {
         archiveClassifier.set("javadoc")

--- a/readium/adapters/pdfium/build.gradle.kts
+++ b/readium/adapters/pdfium/build.gradle.kts
@@ -57,6 +57,6 @@ publishing {
 }
 
 dependencies {
-    api(project(":readium:adapters:pdfium:pdfium-document"))
-    api(project(":readium:adapters:pdfium:pdfium-navigator"))
+    api("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-document")
+    api("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-navigator")
 }

--- a/readium/adapters/pdfium/build.gradle.kts
+++ b/readium/adapters/pdfium/build.gradle.kts
@@ -57,6 +57,6 @@ publishing {
 }
 
 dependencies {
-    api("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-document")
-    api("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-navigator")
+    api(project(":readium:adapters:pdfium:readium-adapter-pdfium-document"))
+    api(project(":readium:adapters:pdfium:readium-adapter-pdfium-navigator"))
 }

--- a/readium/adapters/pdfium/pdfium-document/build.gradle.kts
+++ b/readium/adapters/pdfium/pdfium-document/build.gradle.kts
@@ -62,7 +62,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api(project(":readium:readium-shared"))
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("com.github.barteksc:pdfium-android:1.8.2")

--- a/readium/adapters/pdfium/pdfium-document/build.gradle.kts
+++ b/readium/adapters/pdfium/pdfium-document/build.gradle.kts
@@ -62,7 +62,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("com.github.barteksc:pdfium-android:1.8.2")

--- a/readium/adapters/pdfium/pdfium-navigator/build.gradle.kts
+++ b/readium/adapters/pdfium/pdfium-navigator/build.gradle.kts
@@ -62,9 +62,9 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
-    api(project(":readium:navigator"))
-    api(project(":readium:adapters:pdfium:pdfium-document"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api("com.github.readium.kotlin-toolkit:readium-navigator")
+    api("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-document")
 
     api("com.github.barteksc:android-pdf-viewer:2.8.2")
     implementation("androidx.fragment:fragment-ktx:1.5.3")

--- a/readium/adapters/pdfium/pdfium-navigator/build.gradle.kts
+++ b/readium/adapters/pdfium/pdfium-navigator/build.gradle.kts
@@ -62,9 +62,9 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
-    api("com.github.readium.kotlin-toolkit:readium-navigator")
-    api("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-document")
+    api(project(":readium:readium-shared"))
+    api(project(":readium:readium-navigator"))
+    api(project(":readium:adapters:pdfium:readium-adapter-pdfium-document"))
 
     api("com.github.barteksc:android-pdf-viewer:2.8.2")
     implementation("androidx.fragment:fragment-ktx:1.5.3")

--- a/readium/adapters/pspdfkit/build.gradle.kts
+++ b/readium/adapters/pspdfkit/build.gradle.kts
@@ -57,6 +57,6 @@ publishing {
 }
 
 dependencies {
-    api(project(":readium:adapters:pspdfkit:pspdfkit-document"))
-    api(project(":readium:adapters:pspdfkit:pspdfkit-navigator"))
+    api("com.github.readium.kotlin-toolkit:readium-adapter-pspdfkit-document")
+    api("com.github.readium.kotlin-toolkit:readium-adapter-pspdfkit-navigator")
 }

--- a/readium/adapters/pspdfkit/build.gradle.kts
+++ b/readium/adapters/pspdfkit/build.gradle.kts
@@ -57,6 +57,6 @@ publishing {
 }
 
 dependencies {
-    api("com.github.readium.kotlin-toolkit:readium-adapter-pspdfkit-document")
-    api("com.github.readium.kotlin-toolkit:readium-adapter-pspdfkit-navigator")
+    api(project(":readium:adapters:pspdfkit:readium-adapter-pspdfkit-document"))
+    api(project(":readium:adapters:pspdfkit:readium-adapter-pspdfkit-navigator"))
 }

--- a/readium/adapters/pspdfkit/pspdfkit-document/build.gradle.kts
+++ b/readium/adapters/pspdfkit/pspdfkit-document/build.gradle.kts
@@ -62,7 +62,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/readium/adapters/pspdfkit/pspdfkit-document/build.gradle.kts
+++ b/readium/adapters/pspdfkit/pspdfkit-document/build.gradle.kts
@@ -62,7 +62,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api(project(":readium:readium-shared"))
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/readium/adapters/pspdfkit/pspdfkit-navigator/build.gradle.kts
+++ b/readium/adapters/pspdfkit/pspdfkit-navigator/build.gradle.kts
@@ -62,9 +62,9 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
-    api(project(":readium:navigator"))
-    api(project(":readium:adapters:pspdfkit:pspdfkit-document"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api("com.github.readium.kotlin-toolkit:readium-navigator")
+    api("com.github.readium.kotlin-toolkit:readium-adapter-pspdfkit-document")
 
     implementation("androidx.fragment:fragment-ktx:1.5.3")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/readium/adapters/pspdfkit/pspdfkit-navigator/build.gradle.kts
+++ b/readium/adapters/pspdfkit/pspdfkit-navigator/build.gradle.kts
@@ -62,9 +62,9 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
-    api("com.github.readium.kotlin-toolkit:readium-navigator")
-    api("com.github.readium.kotlin-toolkit:readium-adapter-pspdfkit-document")
+    api(project(":readium:readium-shared"))
+    api(project(":readium:readium-navigator"))
+    api(project(":readium:adapters:pspdfkit:readium-adapter-pspdfkit-document"))
 
     implementation("androidx.fragment:fragment-ktx:1.5.3")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api(project(":readium:readium-shared"))
 
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.core:core-ktx:1.9.0")

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
-    api(project(":readium:shared"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
 
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.core:core-ktx:1.9.0")

--- a/readium/navigator-media2/build.gradle.kts
+++ b/readium/navigator-media2/build.gradle.kts
@@ -63,8 +63,8 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
-    api("com.github.readium.kotlin-toolkit:readium-navigator")
+    api(project(":readium:readium-shared"))
+    api(project(":readium:readium-navigator"))
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")

--- a/readium/navigator-media2/build.gradle.kts
+++ b/readium/navigator-media2/build.gradle.kts
@@ -63,8 +63,8 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
-    api(project(":readium:navigator"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api("com.github.readium.kotlin-toolkit:readium-navigator")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")

--- a/readium/navigator/build.gradle.kts
+++ b/readium/navigator/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
 
     implementation("androidx.activity:activity-ktx:1.6.0")
     implementation("androidx.appcompat:appcompat:1.5.1")

--- a/readium/navigator/build.gradle.kts
+++ b/readium/navigator/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api(project(":readium:readium-shared"))
 
     implementation("androidx.activity:activity-ktx:1.6.0")
     implementation("androidx.appcompat:appcompat:1.5.1")

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/media/ExoMediaPlayer.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/media/ExoMediaPlayer.kt
@@ -114,7 +114,7 @@ class ExoMediaPlayer(
         .apply {
             setMediaSessionToken(mediaSession.sessionToken)
             setPlayer(player)
-            setSmallIcon(R.drawable.exo_notification_small_icon)
+            setSmallIcon(com.google.android.exoplayer2.ui.R.drawable.exo_notification_small_icon)
             setUsePlayPauseActions(true)
             setUseStopAction(false)
             setUseChronometer(false)

--- a/readium/opds/build.gradle.kts
+++ b/readium/opds/build.gradle.kts
@@ -59,7 +59,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api(project(":readium:readium-shared"))
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/readium/opds/build.gradle.kts
+++ b/readium/opds/build.gradle.kts
@@ -59,7 +59,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/readium/streamer/build.gradle.kts
+++ b/readium/streamer/build.gradle.kts
@@ -60,7 +60,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api(project(":readium:shared"))
+    api("com.github.readium.kotlin-toolkit:readium-shared")
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     @Suppress("GradleDependency")

--- a/readium/streamer/build.gradle.kts
+++ b/readium/streamer/build.gradle.kts
@@ -60,7 +60,7 @@ publishing {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    api("com.github.readium.kotlin-toolkit:readium-shared")
+    api(project(":readium:readium-shared"))
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     @Suppress("GradleDependency")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,15 +45,44 @@ dependencyResolutionManagement {
 rootProject.name = "Readium"
 
 include(":readium:adapters:pdfium:pdfium-document")
+project(":readium:adapters:pdfium:pdfium-document")
+    .name = "readium-adapter-pdfium-document"
+
 include(":readium:adapters:pdfium:pdfium-navigator")
+project(":readium:adapters:pdfium:pdfium-navigator")
+    .name = "readium-adapter-pdfium-navigator"
+
 include(":readium:adapters:pspdfkit:pspdfkit-document")
+project(":readium:adapters:pspdfkit:pspdfkit-document")
+    .name = "readium-adapter-pspdfkit-document"
+
 include(":readium:adapters:pspdfkit:pspdfkit-navigator")
+project(":readium:adapters:pspdfkit:pspdfkit-navigator")
+    .name = "readium-adapter-pspdfkit-navigator"
+
 include(":readium:lcp")
+project(":readium:lcp")
+    .name = "readium-lcp"
+
 include(":readium:navigator")
+project(":readium:navigator")
+    .name = "readium-navigator"
+
 include(":readium:navigator-media2")
+project(":readium:navigator-media2")
+    .name = "readium-navigator-media2"
+
 include(":readium:opds")
+project(":readium:opds")
+    .name = "readium-opds"
+
 include(":readium:shared")
+project(":readium:shared")
+    .name = "readium-shared"
+
 include(":readium:streamer")
+project(":readium:streamer")
+    .name = "readium-streamer"
 
 if (System.getenv("JITPACK") == null) {
     include("test-app")

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -66,15 +66,15 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
 
-    implementation("com.github.readium.kotlin-toolkit:readium-shared")
-    implementation("com.github.readium.kotlin-toolkit:readium-streamer")
-    implementation("com.github.readium.kotlin-toolkit:readium-navigator")
-    implementation("com.github.readium.kotlin-toolkit:readium-navigator-media2")
-    implementation("com.github.readium.kotlin-toolkit:readium-opds")
-    implementation("com.github.readium.kotlin-toolkit:readium-lcp")
+    implementation(project(":readium:readium-shared"))
+    implementation(project(":readium:readium-streamer"))
+    implementation(project(":readium:readium-navigator"))
+    implementation(project(":readium:readium-navigator-media2"))
+    implementation(project(":readium:readium-opds"))
+    implementation(project(":readium:readium-lcp"))
     // Only required if you want to support PDF files using PDFium.
-    implementation("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-document")
-    implementation("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-navigator")
+    implementation(project(":readium:adapters:pdfium:readium-adapter-pdfium-document"))
+    implementation(project(":readium:adapters:pdfium:readium-adapter-pdfium-navigator"))
 
     implementation("androidx.activity:activity-compose:1.6.0")
     implementation("androidx.activity:activity-ktx:1.6.0")

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -66,14 +66,15 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
 
-    implementation(project(":readium:shared"))
-    implementation(project(":readium:streamer"))
-    implementation(project(":readium:navigator"))
-    implementation(project(":readium:navigator-media2"))
-    implementation(project(":readium:opds"))
-    implementation(project(":readium:lcp"))
+    implementation("com.github.readium.kotlin-toolkit:readium-shared")
+    implementation("com.github.readium.kotlin-toolkit:readium-streamer")
+    implementation("com.github.readium.kotlin-toolkit:readium-navigator")
+    implementation("com.github.readium.kotlin-toolkit:readium-navigator-media2")
+    implementation("com.github.readium.kotlin-toolkit:readium-opds")
+    implementation("com.github.readium.kotlin-toolkit:readium-lcp")
     // Only required if you want to support PDF files using PDFium.
-    implementation(project(":readium:adapters:pdfium"))
+    implementation("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-document")
+    implementation("com.github.readium.kotlin-toolkit:readium-adapter-pdfium-navigator")
 
     implementation("androidx.activity:activity-compose:1.6.0")
     implementation("androidx.activity:activity-ktx:1.6.0")


### PR DESCRIPTION
Recommend to use a [Gradle Composite build](https://docs.gradle.org/current/userguide/composite_builds.html) to integrate the Readium toolkit as a local clone. This simplifies significantly the setup in the host app.

I decided to use the same group and artifact IDs as JitPack. This allows an app to write:

```
implementation 'com.github.readium.kotlin-toolkit:readium-shared'
```

to reference the official JitPack binaries. Then, just by adding `includeBuild 'readium'`, it will switch to a local submodule. 