### PR TITLE
Fix broken dependency to NanoHTTPD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Fixed
+
+#### Streamer
+
+* [#286](https://github.com/readium/kotlin-toolkit/issues/286) Fixed broken dependency to NanoHTTPD.
+
 
 ## [2.2.0]
 

--- a/readium/streamer/build.gradle.kts
+++ b/readium/streamer/build.gradle.kts
@@ -61,10 +61,10 @@ dependencies {
     @Suppress("GradleDependency")
     implementation("com.github.barteksc:pdfium-android:1.8.2")
     implementation("com.jakewharton.timber:timber:5.0.1")
-    implementation("com.github.edrlab.nanohttpd:nanohttpd:master-SNAPSHOT") {
+    api("com.github.readium.nanohttpd:nanohttpd:master-SNAPSHOT") {
         exclude(group = "org.parboiled")
     }
-    implementation("com.github.edrlab.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT") {
+    api("com.github.readium.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT") {
         exclude(group = "org.parboiled")
     }
     //AM NOTE: conflicting support libraries, excluding these

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -87,12 +87,6 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.2.1")
     implementation("androidx.viewpager2:viewpager2:1.0.0")
     implementation("androidx.webkit:webkit:1.4.0")
-    implementation("com.github.edrlab.nanohttpd:nanohttpd:master-SNAPSHOT") {
-        exclude(group = "org.parboiled")
-    }
-    implementation("com.github.edrlab.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT") {
-        exclude(group = "org.parboiled")
-    }
     implementation("com.google.android.material:material:1.5.0")
     implementation("com.jakewharton.timber:timber:5.0.1")
     // AM NOTE: needs to stay this version for now (June 24,2020)


### PR DESCRIPTION
### Fixed

#### Streamer

* [#286](https://github.com/readium/kotlin-toolkit/issues/286) Fixed broken dependency to NanoHTTPD.
---
Original fix by @stevenzeck from https://github.com/readium/kotlin-toolkit/pull/287