### PR TITLE
Fix documentation config errors and use README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run Dokka
         run: ./gradlew dokkaGfmMultiModule
 
+      - name: Copy README.md into docs to replace Dokka index.md
+        run: cp README.md index.md
+
       - name: Run MkDocs
         run: |
           git config --global user.name "${GITHUB_ACTOR}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,11 +56,12 @@ nav:
       - Navigator: readium/navigator/index.md
       - OPDS: readium/opds/index.md
       - LCP: readium/lcp/index.md
-      - Navigator media2: readium/navigator-media2/index.md
-      - PDFium Document: readium/adapters/pdfium/pdfium-document/index.md
-      - PDFium Navigator: readium/adapters/pdfium/pdfium-navigator/index.md
-      - Pspdfkit Document: readium/adapters/pspdfkit/pspdfkit-document/index.md
-      - Pspdfkit Navigator: readium/adapters/pspdfkit/pspdfkit-navigator/index.md
+      - Adapters:
+          - Navigator media2: readium/navigator-media2/index.md
+          - PDFium Document: readium/adapters/pdfium/pdfium-document/index.md
+          - PDFium Navigator: readium/adapters/pdfium/pdfium-navigator/index.md
+          - Pspdfkit Document: readium/adapters/pspdfkit/pspdfkit-document/index.md
+          - Pspdfkit Navigator: readium/adapters/pspdfkit/pspdfkit-navigator/index.md
 
 extra_css:
   - readium_colors.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,8 +60,8 @@ nav:
           - Navigator media2: readium/navigator-media2/index.md
           - PDFium Document: readium/adapters/pdfium/pdfium-document/index.md
           - PDFium Navigator: readium/adapters/pdfium/pdfium-navigator/index.md
-          - Pspdfkit Document: readium/adapters/pspdfkit/pspdfkit-document/index.md
-          - Pspdfkit Navigator: readium/adapters/pspdfkit/pspdfkit-navigator/index.md
+          - PSPDFKit Document: readium/adapters/pspdfkit/pspdfkit-document/index.md
+          - PSPDFKit Navigator: readium/adapters/pspdfkit/pspdfkit-navigator/index.md
 
 extra_css:
   - readium_colors.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,19 +42,25 @@ markdown_extensions:
 #dev_addr: 127.0.0.1:3001
 
 nav:
+  - Home: index.md
   - Migration Guide: migration-guide.md
   - User Guides:
-    - Navigator settings: guides/navigator-settings.md
+      - Navigator settings: guides/navigator-settings.md
       - Adding custom fonts: guides/epub-custom-fonts.md
-    - PDF support: guides/pdf.md
-    - Text-to-speech: guides/tts.md
-    - Extracting the content of a publication: guides/content.md
+      - PDF support: guides/pdf.md
+      - Text-to-speech: guides/tts.md
+      - Extracting the content of a publication: guides/content.md
   - API Reference:
       - Shared: readium/shared/index.md
       - Streamer: readium/streamer/index.md
       - Navigator: readium/navigator/index.md
       - OPDS: readium/opds/index.md
       - LCP: readium/lcp/index.md
+      - Navigator media2: readium/navigator-media2/index.md
+      - PDFium Document: readium/adapters/pdfium/pdfium-document/index.md
+      - PDFium Navigator: readium/adapters/pdfium/pdfium-navigator/index.md
+      - Pspdfkit Document: readium/adapters/pspdfkit/pspdfkit-document/index.md
+      - Pspdfkit Navigator: readium/adapters/pspdfkit/pspdfkit-navigator/index.md
 
 extra_css:
   - readium_colors.css

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ pluginManagement {
     plugins {
         id("com.android.application") version ("7.2.2")
         id("com.android.library") version ("7.2.2")
-        id("org.jetbrains.kotlin.android") version ("1.7.20")
+        id("org.jetbrains.kotlin.android") version ("1.7.10")
         id("org.jetbrains.dokka") version ("1.7.20")
         id("org.jetbrains.kotlin.plugin.serialization") version ("1.7.10")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ pluginManagement {
     plugins {
         id("com.android.application") version ("7.2.2")
         id("com.android.library") version ("7.2.2")
-        id("org.jetbrains.kotlin.android") version ("1.7.10")
+        id("org.jetbrains.kotlin.android") version ("1.7.20")
         id("org.jetbrains.dokka") version ("1.7.20")
         id("org.jetbrains.kotlin.plugin.serialization") version ("1.7.10")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ pluginManagement {
         id("com.android.application") version ("7.2.2")
         id("com.android.library") version ("7.2.2")
         id("org.jetbrains.kotlin.android") version ("1.7.10")
-        id("org.jetbrains.dokka") version ("1.7.10")
+        id("org.jetbrains.dokka") version ("1.7.20")
         id("org.jetbrains.kotlin.plugin.serialization") version ("1.7.10")
     }
 }


### PR DESCRIPTION
- Addresses a formatting issue in mkdocs.yml file that prevented the `mike` command from running
- Added missing index files for media2, PDFium, and Pspdfkit under "Adapters", which is also under "API Reference". Unsure of case sensitivity for PDFium and Pspdfkit, so feel free to correct
- Updated the docs workflow to copy the README.md from the root project into the docs folder and replace the index.md file that is generated by Dokka. The one from Dokka is just links to the APIs, which we have in the left nav anyways