### PR TITLE
Fix broken pagination when an EPUB uses `overflow-x: hidden`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable changes to this project will be documented in this file. Take a look
 * The `onTap` event is not sent when an EPUB text selection is active anymore, to prevent showing the app bar while dismissing a selection.
 * [#76](https://github.com/readium/kotlin-toolkit/issues/76) Fixed EPUB fixed layout font size affected by device settings.
 * `Decoration` objects are now properly comparable with `equals()`.
+* [#292](https://github.com/readium/kotlin-toolkit/issues/292) Fix broken pagination when an EPUB uses `overflow-x: hidden`.
 
 
 ## [2.2.1]

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/css/ReadiumCss.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/css/ReadiumCss.kt
@@ -57,6 +57,16 @@ internal data class ReadiumCss(
             // https://github.com/readium/r2-navigator-kotlin/issues/193
             add("<style>audio[controls] { width: revert; height: revert; }</style>")
 
+            // Fix broken pagination when a book contains `overflow-x: hidden`.
+            // https://github.com/readium/kotlin-toolkit/issues/292
+            // Inspired by https://github.com/readium/readium-css/issues/119#issuecomment-1302348238
+            add("""
+                <style>
+                    :root[style], :root { overflow: visible !important; }
+                    :root[style] > body, :root > body { overflow: visible !important; }
+                </style>
+            """.trimMargin())
+
             if (!hasStyles) {
                 add(stylesheetLink(stylesheetsFolder + "ReadiumCSS-default.css"))
             }

--- a/readium/navigator/src/test/java/org/readium/r2/navigator/epub/css/ReadiumCssTest.kt
+++ b/readium/navigator/src/test/java/org/readium/r2/navigator/epub/css/ReadiumCssTest.kt
@@ -31,6 +31,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -72,6 +76,10 @@ class HtmlInjectionTest {
                     <head xmlns:xlink="http://www.w3.org/1999/xlink">
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -111,6 +119,10 @@ class HtmlInjectionTest {
                 <?xml version="1.0" encoding="utf-8"?><html dir="ltr" xmlns="http://www.w3.org/1999/xhtml"><head xmlns:xlink="http://www.w3.org/1999/xlink">
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 <title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-after.css"/>
                 </head><body dir="ltr" xmlns:xlink="http://www.w3.org/1999/xlink"></body></html>
@@ -138,6 +150,10 @@ class HtmlInjectionTest {
                 <?xml version="1.0" encoding="utf-8"?><HTML dir="ltr" xmlns="http://www.w3.org/1999/xhtml"><HEAD xmlns:xlink="http://www.w3.org/1999/xlink">
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 <title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-after.css"/>
                 </HEAD><BODY dir="ltr" xmlns:xlink="http://www.w3.org/1999/xlink"></BODY></HTML>
@@ -167,6 +183,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-default.css"/>
                 
                         <title>Publication</title>
@@ -265,6 +285,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/rtl/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -306,6 +330,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/cjk-horizontal/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -348,6 +376,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/cjk-vertical/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -389,6 +421,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -430,6 +466,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -471,6 +511,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -512,6 +556,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -558,6 +606,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
@@ -604,6 +656,10 @@ class HtmlInjectionTest {
                     <head>
                 <link rel="stylesheet" type="text/css" href="/assets/readium/readium-css/ReadiumCSS-before.css"/>
                 <style>audio[controls] { width: revert; height: revert; }</style>
+                                <style>
+                                    :root[style], :root { overflow: visible !important; }
+                                    :root[style] > body, :root > body { overflow: visible !important; }
+                                </style>
                 
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -89,6 +89,16 @@ internal class HtmlInjector(
             </style>
         """.trimIndent())
 
+        // Fix broken pagination when a book contains `overflow-x: hidden`.
+        // https://github.com/readium/kotlin-toolkit/issues/292
+        // Inspired by https://github.com/readium/readium-css/issues/119#issuecomment-1302348238
+        beginIncludes.add("""
+            <style>
+                :root[style], :root { overflow: visible !important; }
+                :root[style] > body, :root > body { overflow: visible !important; }
+            </style>
+        """.trimMargin())
+
         endIncludes.add(getHtmlLink("/assets/readium-css/${layout.readiumCSSPath}ReadiumCSS-after.css"))
         endIncludes.add(getHtmlScript("/assets/scripts/readium-reflowable.js"))
 

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
@@ -21,7 +21,10 @@ class HtmlInjectorTest {
                     width: revert;
                     height: revert;
                 }
-                </style>
+                </style>            <style>
+                                :root[style], :root { overflow: visible !important; }
+                                :root[style] > body, :root > body { overflow: visible !important; }
+                            </style>
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
                     <link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
@@ -59,7 +62,10 @@ class HtmlInjectorTest {
                     width: revert;
                     height: revert;
                 }
-                </style>
+                </style>            <style>
+                                :root[style], :root { overflow: visible !important; }
+                                :root[style] > body, :root > body { overflow: visible !important; }
+                            </style>
                         <title>Publication</title>
                         <link rel="stylesheet" href="style.css" type="text/css"/>
                     <link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
@@ -95,7 +101,10 @@ class HtmlInjectorTest {
                     width: revert;
                     height: revert;
                 }
-                </style><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                </style>            <style>
+                                :root[style], :root { overflow: visible !important; }
+                                :root[style] > body, :root > body { overflow: visible !important; }
+                            </style><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
                 <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
                 <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
                 <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
@@ -121,7 +130,10 @@ class HtmlInjectorTest {
                     width: revert;
                     height: revert;
                 }
-                </style><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                </style>            <style>
+                                :root[style], :root { overflow: visible !important; }
+                                :root[style] > body, :root > body { overflow: visible !important; }
+                            </style><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
                 <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
                 <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
                 <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>


### PR DESCRIPTION
### Fixed

#### Navigator

* [#292](https://github.com/readium/kotlin-toolkit/issues/292) Fix broken pagination when an EPUB uses `overflow-x: hidden`.

---

* Fix #292 