### PR TITLE
Allow to bypass the selection protection with LCP

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -41,7 +41,17 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
-import org.readium.r2.navigator.*
+import org.readium.r2.navigator.DecorableNavigator
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.DecorationId
+import org.readium.r2.navigator.ExperimentalDecorator
+import org.readium.r2.navigator.ExperimentalDragGesture
+import org.readium.r2.navigator.NavigatorDelegate
+import org.readium.r2.navigator.R
+import org.readium.r2.navigator.R2BasicWebView
+import org.readium.r2.navigator.SelectableNavigator
+import org.readium.r2.navigator.Selection
+import org.readium.r2.navigator.VisualNavigator
 import org.readium.r2.navigator.databinding.ActivityR2ViewpagerBinding
 import org.readium.r2.navigator.epub.EpubNavigatorViewModel.RunScriptCommand
 import org.readium.r2.navigator.epub.css.FontFamilyDeclaration
@@ -59,8 +69,8 @@ import org.readium.r2.navigator.preferences.Configurable
 import org.readium.r2.navigator.preferences.FontFamily
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.navigator.util.createFragmentFactory
+import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.ExperimentalReadiumApi
-import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.tryOrLog
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.publication.Link
@@ -165,7 +175,7 @@ class EpubNavigatorFragment internal constructor(
          * application. If you need help, follow up on:
          * https://github.com/readium/kotlin-toolkit/issues/299#issuecomment-1315643577
          */
-        @InternalReadiumApi
+        @DelicateReadiumApi
         val disableSelectionWhenProtected: Boolean = true
     ) {
         /**

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -66,6 +66,7 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
+import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.presentation
 import org.readium.r2.shared.publication.services.isRestricted
@@ -154,7 +155,18 @@ class EpubNavigatorFragment internal constructor(
          */
         val shouldApplyInsetsPadding: Boolean? = true,
 
-        internal val javascriptInterfaces: MutableMap<String, JavascriptInterfaceFactory> = mutableMapOf()
+        internal val javascriptInterfaces: MutableMap<String, JavascriptInterfaceFactory> = mutableMapOf(),
+
+        /**
+         * Disable user selection if the publication is protected by a DRM (e.g. with LCP).
+         *
+         * WARNING: If you choose to disable this, you MUST remove the Copy and Share selection
+         * menu items in your app. Otherwise, you will void the EDRLab certification for your
+         * application. If you need help, follow up on:
+         * https://github.com/readium/kotlin-toolkit/issues/299#issuecomment-1315643577
+         */
+        @InternalReadiumApi
+        val disableSelectionWhenProtected: Boolean = true
     ) {
         /**
          * Registers a new factory for the [JavascriptInterface] named [name].

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -60,13 +60,13 @@ import org.readium.r2.navigator.preferences.FontFamily
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.navigator.util.createFragmentFactory
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.tryOrLog
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
-import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.presentation
 import org.readium.r2.shared.publication.services.isRestricted

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -386,7 +386,11 @@ internal class EpubNavigatorViewModel(
                 defaults = defaults,
                 baseUrl = baseUrl,
                 server = if (baseUrl != null) null
-                else WebViewServer(application, publication, servedAssets = config.servedAssets)
+                else WebViewServer(
+                    application, publication,
+                    servedAssets = config.servedAssets,
+                    disableSelectionWhenProtected = config.disableSelectionWhenProtected
+                )
             )
         }
     }

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
@@ -22,7 +22,12 @@ import timber.log.Timber
  * @param baseHref Base URL where the Readium CSS and scripts are served.
  */
 @OptIn(ExperimentalReadiumApi::class)
-internal fun Resource.injectHtml(publication: Publication, css: ReadiumCss, baseHref: String, disableSelectionWhenProtected: Boolean): Resource =
+internal fun Resource.injectHtml(
+    publication: Publication,
+    css: ReadiumCss,
+    baseHref: String,
+    disableSelectionWhenProtected: Boolean
+): Resource =
     TransformingResource(this) { bytes ->
         val link = link()
         check(link.mediaType.isHtml)

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
@@ -22,7 +22,7 @@ import timber.log.Timber
  * @param baseHref Base URL where the Readium CSS and scripts are served.
  */
 @OptIn(ExperimentalReadiumApi::class)
-internal fun Resource.injectHtml(publication: Publication, css: ReadiumCss, baseHref: String): Resource =
+internal fun Resource.injectHtml(publication: Publication, css: ReadiumCss, baseHref: String, disableSelectionWhenProtected: Boolean): Resource =
     TransformingResource(this) { bytes ->
         val link = link()
         check(link.mediaType.isHtml)
@@ -40,7 +40,7 @@ internal fun Resource.injectHtml(publication: Publication, css: ReadiumCss, base
 
         // Disable the text selection if the publication is protected.
         // FIXME: This is a hack until proper LCP copy is implemented, see https://github.com/readium/kotlin-toolkit/issues/221
-        if (publication.isProtected) {
+        if (disableSelectionWhenProtected && publication.isProtected) {
             injectables.add(
                 """
                 <style>

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/WebViewServer.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/WebViewServer.kt
@@ -35,6 +35,7 @@ internal class WebViewServer(
     private val application: Application,
     private val publication: Publication,
     servedAssets: List<String>,
+    private val disableSelectionWhenProtected: Boolean
 ) {
     companion object {
         val publicationBaseHref = "https://readium/publication/"
@@ -85,7 +86,11 @@ internal class WebViewServer(
         var resource = publication.get(link)
             .fallback { errorResource(link, error = it) }
         if (link.mediaType.isHtml) {
-            resource = resource.injectHtml(publication, css, baseHref = assetsBaseHref)
+            resource = resource.injectHtml(
+                publication, css,
+                baseHref = assetsBaseHref,
+                disableSelectionWhenProtected = disableSelectionWhenProtected
+            )
         }
 
         val headers = mutableMapOf(


### PR DESCRIPTION
As [LCP copy rights are not yet implemented](https://github.com/readium/kotlin-toolkit/issues/299#issuecomment-1315643577) in the Kotlin toolkit, the text selection is disabled in an LCP protected EPUB.

This is an issue for many implementers that want to support highlighting an LCP protected EPUB. This PR adds a new `disableSelectionWhenProtected` EPUB config option to disable the protection without having to fork the toolkit.

However, if you choose to use it, you MUST remove the Copy and Share selection menu items in your app. Otherwise, you will void the EDRLab certification for your application.