### PR TITLE
Fix scroll inertia when scrolling an EPUB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file. Take a look
     * `paragraphSpacing` - Vertical margins for paragraphs.
     * `hyphens` - Enable hyphenation.
     * `ligatures` - Enable ligatures in Arabic.
+* Fixed scroll inertia when scrolling an EPUB.
 
 ### Changed
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2WebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2WebView.kt
@@ -186,6 +186,8 @@ class R2WebView(context: Context, attrs: AttributeSet) : R2BasicWebView(context,
 
     private var mScrollState = SCROLL_STATE_IDLE
 
+    internal var useLegacySettings = false
+
     private fun initWebPager() {
         setWillNotDraw(false)
         descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
@@ -550,6 +552,10 @@ class R2WebView(context: Context, attrs: AttributeSet) : R2BasicWebView(context,
     }
 
     override fun computeScroll() {
+        if (!useLegacySettings && scrollMode) {
+            return super.computeScroll()
+        }
+
         mIsScrollStarted = true
         if (!mScroller!!.isFinished && mScroller!!.computeScrollOffset()) {
             val oldX = scrollX

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -235,6 +235,9 @@ internal class EpubNavigatorViewModel(
                 oldSettings.language != newSettings.language ||
                 oldSettings.verticalText != newSettings.verticalText ||
                 oldSettings.spread != newSettings.spread ||
+                // We need to invalidate the resource pager when changing from scroll mode to
+                // paginated, otherwise the horizontal scroll will be broken.
+                // See https://github.com/readium/kotlin-toolkit/pull/304
                 oldSettings.scroll != newSettings.scroll
             )
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -234,7 +234,8 @@ internal class EpubNavigatorViewModel(
             oldSettings.readingProgression != newSettings.readingProgression ||
                 oldSettings.language != newSettings.language ||
                 oldSettings.verticalText != newSettings.verticalText ||
-                oldSettings.spread != newSettings.spread
+                oldSettings.spread != newSettings.spread ||
+                oldSettings.scroll != newSettings.scroll
             )
 
         if (needsInvalidation) {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -139,6 +139,7 @@ class R2EpubPageFragment : Fragment() {
             @Suppress("DEPRECATION")
             webView.setScrollMode(preferences.getBoolean(SCROLL_REF, false))
         }
+        webView.useLegacySettings = viewModel.useLegacySettings
         webView.settings.javaScriptEnabled = true
         webView.isVerticalScrollBarEnabled = false
         webView.isHorizontalScrollBarEnabled = false


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed scroll inertia when scrolling an EPUB.

---

Note that this is only fixed with the new Settings API, because it requires invalidating the resource pager which is not supported by the legacy one.


https://user-images.githubusercontent.com/58686775/205715747-6e5f6430-3b06-4ef0-a705-abe23f1b3340.mov

