### PR TITLE
Fix parsing of the EPUB accessibility profile

### DIFF
--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/AccessibilityAdapter.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/AccessibilityAdapter.kt
@@ -61,7 +61,7 @@ internal class AccessibilityAdapter {
     private fun conformedToProfileOrNull(item: MetadataItem): Accessibility.Profile? =
         if (item is MetadataItem.Meta && item.property == Vocabularies.DCTERMS + "conformsTo") {
             accessibilityProfileFromString(item.value)
-        } else if (item is MetadataItem.Link && item.href == Vocabularies.DCTERMS + "conformsTo") {
+        } else if (item is MetadataItem.Link && item.rels.contains(Vocabularies.DCTERMS + "conformsTo")) {
             accessibilityProfileFromString(item.href)
         } else
             null

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub3.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub3.opf
@@ -4,7 +4,7 @@
     <dc:title>Alice's Adventures in Wonderland</dc:title>
 
     <dc:conformsTo>any profile</dc:conformsTo>
-    <dc:conformsTo>http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</dc:conformsTo>
+    <link href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a" rel="dcterms:conformsTo"/>
     <meta property="schema:accessibilitySummary">The publication contains structural and page navigation.</meta>
 
     <meta property="schema:accessMode">textual</meta>


### PR DESCRIPTION
The EPUB parser was not properly parsing the accessibility profile when using `<link>` instead of `<meta>`.