### PR TITLE
EPUB: Option to revert to the 2.2.0 font size strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Added
+
+#### Navigator
+
+* New `EPUBNavigatorFragment.Configuration.useNativeFontSizeStrategy` option to revert to the 2.2.0 strategy for setting the font size of reflowable EPUB publications.
+    * The native font size strategy introduced in 2.3.0 uses the Android web view's [`WebSettings.textZoom`](https://developer.android.com/reference/android/webkit/WebSettings#setTextZoom(int)) property to adjust the font size. 2.2.0 was using Readium CSS's [`--USER__fontSize` variable](https://readium.org/readium-css/docs/CSS12-user_prefs.html#font-size).
+    * `WebSettings.textZoom` will work with more publications than `--USER__fontSize`, even the ones poorly authored. However the page width is not adjusted when changing the font size to keep the optimal line length.
 
 ## [2.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 #### Navigator
 
-* New `EPUBNavigatorFragment.Configuration.useNativeFontSizeStrategy` option to revert to the 2.2.0 strategy for setting the font size of reflowable EPUB publications.
+* New `EPUBNavigatorFragment.Configuration.useReadiumCssFontSize` option to revert to the 2.2.0 strategy for setting the font size of reflowable EPUB publications.
     * The native font size strategy introduced in 2.3.0 uses the Android web view's [`WebSettings.textZoom`](https://developer.android.com/reference/android/webkit/WebSettings#setTextZoom(int)) property to adjust the font size. 2.2.0 was using Readium CSS's [`--USER__fontSize` variable](https://readium.org/readium-css/docs/CSS12-user_prefs.html#font-size).
     * `WebSettings.textZoom` will work with more publications than `--USER__fontSize`, even the ones poorly authored. However the page width is not adjusted when changing the font size to keep the optimal line length.
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -86,7 +86,7 @@ typealias JavascriptInterfaceFactory = (resource: Link) -> Any?
  *
  * To use this [Fragment], create a factory with `EpubNavigatorFragment.createFactory()`.
  */
-@OptIn(ExperimentalDecorator::class, ExperimentalReadiumApi::class)
+@OptIn(ExperimentalDecorator::class, ExperimentalReadiumApi::class, DelicateReadiumApi::class)
 class EpubNavigatorFragment internal constructor(
     override val publication: Publication,
     private val baseUrl: String?,
@@ -133,11 +133,11 @@ class EpubNavigatorFragment internal constructor(
         var readiumCssRsProperties: RsProperties,
 
         /**
-         * When true, the Android web view's `WebSettings.textZoom` will be used to adjust the font
-         * size, instead of using the Readium CSS's `--USER__fontSize` variable.
+         * When disabled, the Android web view's `WebSettings.textZoom` will be used to adjust the
+         * font size, instead of using the Readium CSS's `--USER__fontSize` variable.
          *
          * `WebSettings.textZoom` will work with more publications than `--USER__fontSize`, even the
-         * ones poorly authored. However the page width is not adjusted when changing the font
+         * ones poorly authored. However, the page width is not adjusted when changing the font
          * size to keep the optimal line length.
          *
          * See:
@@ -145,7 +145,8 @@ class EpubNavigatorFragment internal constructor(
          *   - https://github.com/readium/mobile/issues/1#issuecomment-652431984
          */
         @ExperimentalReadiumApi
-        var useNativeFontSizeStrategy: Boolean = true,
+        @DelicateReadiumApi
+        var useReadiumCssFontSize: Boolean = true,
 
         /**
          * Supported HTML decoration templates.
@@ -518,7 +519,7 @@ class EpubNavigatorFragment internal constructor(
     }
 
     private fun R2PagerAdapter.setFontSize(fontSize: Double) {
-        if (!config.useNativeFontSizeStrategy) return
+        if (config.useReadiumCssFontSize) return
 
         mFragments.forEach { _, fragment ->
             (fragment as? R2EpubPageFragment)?.setFontSize(fontSize)
@@ -528,7 +529,7 @@ class EpubNavigatorFragment internal constructor(
     private inner class PagerAdapterListener : R2PagerAdapter.Listener {
         override fun onCreatePageFragment(fragment: Fragment) {
             if (viewModel.layout == EpubLayout.REFLOWABLE) {
-                if (config.useNativeFontSizeStrategy) {
+                if (!config.useReadiumCssFontSize) {
                     (fragment as? R2EpubPageFragment)?.setFontSize(settings.value.fontSize)
                 }
             }

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -118,7 +118,7 @@ internal class EpubNavigatorViewModel(
             fontFamilyDeclarations = config.fontFamilyDeclarations,
             googleFonts = googleFonts,
             assetsBaseHref = WebViewServer.assetsBaseHref
-        ).update(settings.value)
+        ).update(settings.value, useNativeFontSizeStrategy = config.useNativeFontSizeStrategy)
     )
 
     init {
@@ -230,7 +230,7 @@ internal class EpubNavigatorViewModel(
 
         val newSettings = settingsPolicy.settings(preferences)
         _settings.value = newSettings
-        css.update { it.update(newSettings) }
+        css.update { it.update(newSettings, useNativeFontSizeStrategy = config.useNativeFontSizeStrategy) }
 
         val needsInvalidation: Boolean = (
             oldSettings.readingProgression != newSettings.readingProgression ||

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -37,6 +37,7 @@ import org.readium.r2.shared.extensions.mapStateIn
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
+import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.util.Href
 
@@ -44,7 +45,7 @@ internal enum class DualPage {
     AUTO, OFF, ON
 }
 
-@OptIn(ExperimentalReadiumApi::class, ExperimentalDecorator::class)
+@OptIn(ExperimentalReadiumApi::class, ExperimentalDecorator::class, DelicateReadiumApi::class)
 internal class EpubNavigatorViewModel(
     application: Application,
     val publication: Publication,
@@ -118,7 +119,7 @@ internal class EpubNavigatorViewModel(
             fontFamilyDeclarations = config.fontFamilyDeclarations,
             googleFonts = googleFonts,
             assetsBaseHref = WebViewServer.assetsBaseHref
-        ).update(settings.value, useNativeFontSizeStrategy = config.useNativeFontSizeStrategy)
+        ).update(settings.value, useReadiumCssFontSize = config.useReadiumCssFontSize)
     )
 
     init {
@@ -230,7 +231,7 @@ internal class EpubNavigatorViewModel(
 
         val newSettings = settingsPolicy.settings(preferences)
         _settings.value = newSettings
-        css.update { it.update(newSettings, useNativeFontSizeStrategy = config.useNativeFontSizeStrategy) }
+        css.update { it.update(newSettings, useReadiumCssFontSize = config.useReadiumCssFontSize) }
 
         val needsInvalidation: Boolean = (
             oldSettings.readingProgression != newSettings.readingProgression ||

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -30,6 +30,7 @@ import org.readium.r2.navigator.html.HtmlDecorationTemplates
 import org.readium.r2.navigator.preferences.*
 import org.readium.r2.navigator.util.createViewModelFactory
 import org.readium.r2.shared.COLUMN_COUNT_REF
+import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.SCROLL_REF
 import org.readium.r2.shared.extensions.addPrefix
@@ -37,7 +38,6 @@ import org.readium.r2.shared.extensions.mapStateIn
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
-import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.util.Href
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
@@ -110,7 +110,7 @@ internal fun ReadiumCss.update(settings: EpubSettings, useReadiumCssFontSize: Bo
                 fontOverride = (fontFamily != null || textNormalization),
                 fontFamily = fontFamily?.toCss(),
                 fontSize = if (useReadiumCssFontSize) Length.Percent(fontSize)
-                    else null,
+                else null,
                 advancedSettings = !publisherStyles,
                 typeScale = typeScale,
                 textAlign = when (textAlign) {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
@@ -65,7 +65,7 @@ data class EpubSettings(
 ) : Configurable.Settings
 
 @OptIn(ExperimentalReadiumApi::class)
-internal fun ReadiumCss.update(settings: EpubSettings): ReadiumCss {
+internal fun ReadiumCss.update(settings: EpubSettings, useNativeFontSizeStrategy: Boolean): ReadiumCss {
 
     fun resolveFontStack(fontFamily: String): List<String> = buildList {
         add(fontFamily)
@@ -109,9 +109,8 @@ internal fun ReadiumCss.update(settings: EpubSettings): ReadiumCss {
                 backgroundColor = backgroundColor?.toCss(),
                 fontOverride = (fontFamily != null || textNormalization),
                 fontFamily = fontFamily?.toCss(),
-                // Font size is handled natively with WebSettings.textZoom.
-                // See https://github.com/readium/mobile/issues/1#issuecomment-652431984
-//                fontSize = fontSize?.let { Length.Percent(it) },
+                fontSize = if (useNativeFontSizeStrategy) null
+                    else Length.Percent(fontSize),
                 advancedSettings = !publisherStyles,
                 typeScale = typeScale,
                 textAlign = when (textAlign) {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
@@ -65,7 +65,7 @@ data class EpubSettings(
 ) : Configurable.Settings
 
 @OptIn(ExperimentalReadiumApi::class)
-internal fun ReadiumCss.update(settings: EpubSettings, useNativeFontSizeStrategy: Boolean): ReadiumCss {
+internal fun ReadiumCss.update(settings: EpubSettings, useReadiumCssFontSize: Boolean): ReadiumCss {
 
     fun resolveFontStack(fontFamily: String): List<String> = buildList {
         add(fontFamily)
@@ -109,8 +109,8 @@ internal fun ReadiumCss.update(settings: EpubSettings, useNativeFontSizeStrategy
                 backgroundColor = backgroundColor?.toCss(),
                 fontOverride = (fontFamily != null || textNormalization),
                 fontFamily = fontFamily?.toCss(),
-                fontSize = if (useNativeFontSizeStrategy) null
-                    else Length.Percent(fontSize),
+                fontSize = if (useReadiumCssFontSize) Length.Percent(fontSize)
+                    else null,
                 advancedSettings = !publisherStyles,
                 typeScale = typeScale,
                 textAlign = when (textAlign) {


### PR DESCRIPTION
### Added

#### Navigator

* New `EPUBNavigatorFragment.Configuration.useReadiumCssFontSize` option to revert to the 2.2.0 strategy for setting the font size of reflowable EPUB publications.
    * The native font size strategy introduced in 2.3.0 uses the Android web view's [`WebSettings.textZoom`](https://developer.android.com/reference/android/webkit/WebSettings#setTextZoom(int)) property to adjust the font size. 2.2.0 was using Readium CSS's [`--USER__fontSize` variable](https://readium.org/readium-css/docs/CSS12-user_prefs.html#font-size).
    * `WebSettings.textZoom` will work with more publications than `--USER__fontSize`, even the ones poorly authored. However the page width is not adjusted when changing the font size to keep the optimal line length.