### PR TITLE
Fixing R2EpubActivity to be usable without a server.

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/R2EpubActivity.kt
@@ -51,7 +51,7 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
     override lateinit var publication: Publication
     override lateinit var publicationIdentifier: String
     override var bookId: Long = -1
-    protected lateinit var baseUrl: String
+    protected var baseUrl: String? = null
 
     override var allowToggleActionBar = true
 
@@ -88,7 +88,7 @@ open class R2EpubActivity : AppCompatActivity(), IR2Activity, IR2Selectable, IR2
         publicationPath = intent.getStringExtra("publicationPath") ?: throw Exception("publicationPath required")
         publicationFileName = intent.getStringExtra("publicationFileName") ?: throw Exception("publicationFileName required")
         publicationIdentifier = publication.metadata.identifier ?: publication.metadata.title
-        baseUrl = intent.getStringExtra("baseUrl") ?: throw Exception("Intent extra `baseUrl` is required. Provide the URL returned by Server.addPublication()")
+        baseUrl = intent.getStringExtra("baseUrl")
 
         val initialLocator = intent.getParcelableExtra("locator") as? Locator
 


### PR DESCRIPTION
With the 2.3.0 update, the docs state that you do not need to provide a baseUrl, but this code was still validating it and throwing an exception.

This PR is removing the requirement for a baseUrl in R2EpubActivity.kt as the underlying EpubNavigatorViewModel.createFactory method is checking that case and serving the file.

I have this running in my app now without it erroring out, so the underlying server is working when null is passed causing it to be created.