### PR TITLE
Fix JavaScript interface injection when rotating the screen

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Fixed
 
+#### Navigator
+
+* [#360](https://github.com/readium/kotlin-toolkit/issues/360) Fix EPUB JavaScript interface injection when rotating the screen on some devices.
+
 #### Streamer
 
 * Fix issue with the TTS starting from the beginning of the chapter instead of the current position.

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -173,16 +173,12 @@ open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebView(conte
         listener?.onProgressionChanged()
     }
 
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-        addJavascriptInterface(this, "Android")
-    }
-
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
+    override fun destroy() {
         // Prevent the web view from leaking when detached
         // See https://github.com/readium/r2-navigator-kotlin/issues/52
         removeJavascriptInterface("Android")
+
+        super.destroy()
     }
 
     @android.webkit.JavascriptInterface

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -165,6 +165,7 @@ class R2EpubPageFragment : Fragment() {
         webView.settings.textZoom = textZoom
         webView.resourceUrl = resourceUrl
         webView.setPadding(0, 0, 0, 0)
+        webView.addJavascriptInterface(webView, "Android")
 
         var endReached = false
         webView.setOnOverScrolledCallback(object : R2BasicWebView.OnOverScrolledCallback {


### PR DESCRIPTION
### Fixed

#### Navigator

* [#360](https://github.com/readium/kotlin-toolkit/issues/360) Fix EPUB JavaScript interface injection when rotating the screen on some devices.

---

* Fix #360 

I partially reverted https://github.com/readium/r2-navigator-kotlin/pull/191. It looks like using `addJavascriptInterface()` from `onAttachedToWindow()` sometimes fail on some devices.