### PR TITLE
Simplify RWPM parsing for packaged publications

### DIFF
--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -34,6 +34,7 @@ import org.readium.r2.shared.asset.AssetRetriever
 import org.readium.r2.shared.extensions.tryOr
 import org.readium.r2.shared.publication.protection.ContentProtection
 import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.mediatype.FormatRegistry
 import org.readium.r2.shared.util.mediatype.MediaType
 import timber.log.Timber
 
@@ -260,12 +261,5 @@ internal class LicensesService(
     }
 
     private val MediaType.fileExtension: String get() =
-        when {
-            matches(MediaType.DIVINA) -> "divina"
-            matches(MediaType.EPUB) -> "epub"
-            matches(MediaType.LCP_PROTECTED_PDF) -> "pdf"
-            matches(MediaType.READIUM_AUDIOBOOK) -> "audiobook"
-            matches(MediaType.READIUM_WEBPUB) -> "webpub"
-            else -> "epub"
-        }
+        FormatRegistry().fileExtension(this) ?: "epub"
 }

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaSessionNavigator.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaSessionNavigator.kt
@@ -45,8 +45,8 @@ private val skipBackwardInterval: Duration = 30.seconds
 @OptIn(ExperimentalTime::class)
 public class MediaSessionNavigator(
     override val publication: Publication,
-    internal val publicationId: PublicationId,
-    private val controller: MediaControllerCompat,
+    public val publicationId: PublicationId,
+    public val controller: MediaControllerCompat,
     public var listener: Listener? = null
 ) : MediaNavigator, CoroutineScope by MainScope() {
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Manifest.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Manifest.kt
@@ -155,28 +155,23 @@ public data class Manifest(
          */
         public fun fromJSON(
             json: JSONObject?,
-            packaged: Boolean = false,
             mediaTypeRetriever: MediaTypeRetriever = MediaTypeRetriever(),
             warnings: WarningLogger? = null
         ): Manifest? {
             json ?: return null
 
             val baseUrl =
-                if (packaged) {
-                    "/"
-                } else {
-                    Link.fromJSONArray(
-                        json.optJSONArray("links"),
-                        mediaTypeRetriever,
-                        warnings = warnings
-                    )
-                        .firstWithRel("self")
-                        ?.href
-                        ?.toUrlOrNull()
-                        ?.removeLastComponent()
-                        ?.toString()
-                        ?: "/"
-                }
+                Link.fromJSONArray(
+                    json.optJSONArray("links"),
+                    mediaTypeRetriever,
+                    warnings = warnings
+                )
+                    .firstWithRel("self")
+                    ?.href
+                    ?.toUrlOrNull()
+                    ?.removeLastComponent()
+                    ?.toString()
+                    ?: "/"
 
             val normalizeHref = { href: String -> Href(href, baseUrl).string }
 
@@ -199,13 +194,6 @@ public data class Manifest(
                 normalizeHref,
                 warnings
             )
-                .map {
-                    if (packaged && "self" in it.rels) {
-                        it.copy(rels = it.rels - "self" + "alternate")
-                    } else {
-                        it
-                    }
-                }
 
             // [readingOrder] used to be [spine], so we parse [spine] as a fallback.
             val readingOrderJSON = (json.remove("readingOrder") ?: json.remove("spine")) as? JSONArray

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/ManifestTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/ManifestTest.kt
@@ -268,53 +268,12 @@ class ManifestTest {
     }
 
     @Test
-    fun `self link is replaced when parsing a package`() {
-        assertEquals(
-            Manifest(
-                metadata = Metadata(localizedTitle = LocalizedString("Title")),
-                links = listOf(Link(href = "/manifest.json", rels = setOf("alternate")))
-            ),
-            Manifest.fromJSON(
-                JSONObject(
-                    """{
-                "metadata": {"title": "Title"},
-                "links": [
-                    {"href": "/manifest.json", "rel": ["self"], "templated": false}
-                ]
-                }"""
-                ),
-                packaged = true
-            )
-        )
-    }
-
-    @Test
-    fun `self link is kept when parsing a remote manifest`() {
-        assertEquals(
-            Manifest(
-                metadata = Metadata(localizedTitle = LocalizedString("Title")),
-                links = listOf(Link(href = "/manifest.json", rels = setOf("self")))
-            ),
-            Manifest.fromJSON(
-                JSONObject(
-                    """{
-                "metadata": {"title": "Title"},
-                "links": [
-                    {"href": "/manifest.json", "rel": ["self"]}
-                ]
-                }"""
-                )
-            )
-        )
-    }
-
-    @Test
-    fun `href are resolved to root when parsing a package`() {
+    fun `href are resolved to root with a relative self link`() {
         val json = JSONObject(
             """{
             "metadata": {"title": "Title"},
             "links": [
-                {"href": "http://example.com/manifest.json", "rel": ["self"], "templated": false}
+                {"href": "manifest.json", "rel": ["self"], "templated": false}
             ],
             "readingOrder": [
                 {"href": "chap1.html", "type": "text/html", "templated": false}
@@ -324,7 +283,7 @@ class ManifestTest {
 
         assertEquals(
             "/chap1.html",
-            Manifest.fromJSON(json, packaged = true)?.readingOrder?.first()?.href
+            Manifest.fromJSON(json)?.readingOrder?.first()?.href
         )
     }
 

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/ParserAssetFactory.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/ParserAssetFactory.kt
@@ -15,7 +15,6 @@ import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.resource.Resource
 import org.readium.r2.shared.resource.ResourceContainer
 import org.readium.r2.shared.resource.RoutingContainer
-import org.readium.r2.shared.resource.StringResource
 import org.readium.r2.shared.util.MessageError
 import org.readium.r2.shared.util.ThrowableError
 import org.readium.r2.shared.util.Try
@@ -87,10 +86,7 @@ internal class ParserAssetFactory(
 
         val container =
             RoutingContainer(
-                local = ResourceContainer(
-                    path = "/manifest.json",
-                    resource = StringResource(manifest.toJSON().toString(), asset.mediaType)
-                ),
+                local = ResourceContainer(path = "/manifest.json", asset.resource),
                 remote = HttpContainer(httpClient, baseUrl)
             )
 

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/ParserAssetFactory.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/ParserAssetFactory.kt
@@ -65,7 +65,7 @@ internal class ParserAssetFactory(
     private suspend fun createParserAssetForManifest(
         asset: Asset.Resource
     ): Try<PublicationParser.Asset, Publication.OpeningException> {
-        val manifest = asset.resource.readAsRwpm(packaged = false)
+        val manifest = asset.resource.readAsRwpm()
             .mapFailure { Publication.OpeningException.ParsingFailed(ThrowableError(it)) }
             .getOrElse { return Try.failure(it) }
 
@@ -118,14 +118,13 @@ internal class ParserAssetFactory(
         )
     }
 
-    private suspend fun Resource.readAsRwpm(packaged: Boolean): Try<Manifest, Exception> =
+    private suspend fun Resource.readAsRwpm(): Try<Manifest, Exception> =
         try {
             val bytes = read().getOrThrow()
             val string = String(bytes, Charset.defaultCharset())
             val json = JSONObject(string)
             val manifest = Manifest.fromJSON(
                 json,
-                packaged = packaged,
                 mediaTypeRetriever = mediaTypeRetriever
             )
                 ?: throw Exception("Failed to parse the RWPM Manifest")

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
@@ -44,7 +44,6 @@ public class ReadiumWebPubParser(
 
         val manifest = Manifest.fromJSON(
             manifestJson,
-            packaged = true,
             mediaTypeRetriever = mediaTypeRetriever
         )
             ?: return Try.failure(


### PR DESCRIPTION
* Don't remove the `self` link anymore, when parsing a packaged publication. They are not supposed to contain a `self` link with an absolute URL.
* Fix file extensions in the LCP service.
* Restore visibility of `MediaSessionNavigator` properties (hiding them was a mistake when migrating to the explicit API mode).