### PR TITLE
Highlight images during text-to-speech

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/media3/tts/TtsNavigator.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/media3/tts/TtsNavigator.kt
@@ -68,7 +68,7 @@ public class TtsNavigator<S : TtsEngine.Settings, P : TtsEngine.Preferences<P>,
                     ?: ttsEngineProvider.createEmptyPreferences()
 
             val contentIterator =
-                TtsContentIterator(publication, tokenizerFactory, initialLocator)
+                TtsUtteranceIterator(publication, tokenizerFactory, initialLocator)
 
             val ttsEngine =
                 ttsEngineProvider.createEngine(publication, actualInitialPreferences)
@@ -279,28 +279,24 @@ public class TtsNavigator<S : TtsEngine.Settings, P : TtsEngine.Preferences<P>,
     private fun TtsPlayer.Utterance.toPosition(): Location {
         val currentLink = publication.readingOrder[position.resourceIndex]
 
-        val utteranceHighlight = publication
+        val utteranceLocator = publication
             .locatorFromLink(currentLink)!!
             .copy(
                 locations = position.locations,
-                text = Locator.Text(
-                    highlight = text,
-                    before = position.textBefore,
-                    after = position.textAfter
-                )
+                text = position.text
             )
 
-        val tokenHighlight = range
-            ?.let { utteranceHighlight.copy(text = utteranceHighlight.text.substring(it)) }
+        val tokenLocator = range
+            ?.let { utteranceLocator.copy(text = utteranceLocator.text.substring(it)) }
 
         return Location(
             href = Href(currentLink.href),
-            textBefore = position.textBefore,
-            textAfter = position.textAfter,
+            textBefore = position.text.before,
+            textAfter = position.text.after,
             utterance = text,
             range = range,
-            utteranceLocator = utteranceHighlight,
-            tokenLocator = tokenHighlight
+            utteranceLocator = utteranceLocator,
+            tokenLocator = tokenLocator
         )
     }
 }


### PR DESCRIPTION
Images were not highlighted during TTS playback because the decoration locator contained a `text.highlight` element, which is incorrect for an image element.

![Screenshot_20230828-104358](https://github.com/readium/kotlin-toolkit/assets/58686775/0e8ee97f-8a11-4485-8671-7c7714d7a8f0)
![Screenshot_20230828-104347](https://github.com/readium/kotlin-toolkit/assets/58686775/5689d58d-58f5-4c59-940d-86f62a67aa0b)
