### PR TITLE
Fix encoding of `Href` query and fragment

### DIFF
--- a/readium/shared/src/androidTest/java/org/readium/r2/shared/util/HrefTest.kt
+++ b/readium/shared/src/androidTest/java/org/readium/r2/shared/util/HrefTest.kt
@@ -279,15 +279,15 @@ class HrefTest {
             Href("/foo%20bar.txt?query=param#anchor", "http://example.com/").string
         )
         assertEquals(
-            "http://absolute.com/foo bar.txt?query=param#Hello world £500",
+            "http://absolute.com/foo bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
             Href(
-                "http://absolute.com/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
+                "http://absolute.com/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
                 "/"
             ).string
         )
         assertEquals(
-            "http://absolute.com/foo bar.txt?query=param#Hello world £500",
-            Href("http://absolute.com/foo bar.txt?query=param#Hello world £500", "/").string
+            "http://absolute.com/foo bar.txt?query=Hello world#Hello world £500",
+            Href("http://absolute.com/foo bar.txt?query=Hello world#Hello world £500", "/").string
         )
         assertEquals(
             "file:///foo bar.txt?query=param#anchor",
@@ -298,15 +298,15 @@ class HrefTest {
             Href("/foo%20bar.txt?query=param#anchor", "file:///root/").string
         )
         assertEquals(
-            "file:///root/foo bar.txt?query=param#Hello world £500",
+            "file:///root/foo bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
             Href(
-                "file:///root/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
+                "file:///root/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
                 "/"
             ).string
         )
         assertEquals(
-            "file:///root/foo bar.txt?query=param#Hello world £500",
-            Href("file:///root/foo bar.txt?query=param#Hello world £500", "/").string
+            "file:///root/foo bar.txt?query=Hello world#Hello world £500",
+            Href("file:///root/foo bar.txt?query=Hello world#Hello world £500", "/").string
         )
     }
 
@@ -676,15 +676,15 @@ class HrefTest {
             Href("/foo%20bar.txt?query=param#anchor", "http://example.com/").percentEncodedString
         )
         assertEquals(
-            "http://absolute.com/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
+            "http://absolute.com/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
             Href(
-                "http://absolute.com/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
+                "http://absolute.com/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
                 "/"
             ).percentEncodedString
         )
         assertEquals(
-            "http://absolute.com/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
-            Href("http://absolute.com/foo bar.txt?query=param#Hello world £500", "/").percentEncodedString
+            "http://absolute.com/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
+            Href("http://absolute.com/foo bar.txt?query=Hello world#Hello world £500", "/").percentEncodedString
         )
         assertEquals(
             "file:///foo%20bar.txt?query=param#anchor",
@@ -701,15 +701,15 @@ class HrefTest {
             ).percentEncodedString
         )
         assertEquals(
-            "file:///root/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
+            "file:///root/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
             Href(
-                "file:///root/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
+                "file:///root/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
                 "/"
             ).percentEncodedString
         )
         assertEquals(
-            "file:///root/foo%20bar.txt?query=param#Hello%20world%20%C2%A3500",
-            Href("file:///root/foo bar.txt?query=param#Hello world £500", "/").percentEncodedString
+            "file:///root/foo%20bar.txt?query=Hello%20world#Hello%20world%20%C2%A3500",
+            Href("file:///root/foo bar.txt?query=Hello world#Hello world £500", "/").percentEncodedString
         )
     }
 


### PR DESCRIPTION
Historically we percent-decoded HREFs because we can have an EPUB with resources containing, for example, a percent character. The way it was implemented caused an issue with `http://` HREF with a fragment or query param containing special characters (e.g. `%` or `#`).

To fix this, I adjusted the HREF parsing to not percent-decode the path but not the fragment and query params.