### PR TITLE
Bugfixes for TTS

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
@@ -134,14 +134,17 @@ public data class Locator(
         }
 
         public fun substring(range: IntRange): Text {
-            highlight ?: return this
-            return tryOr(this) {
-                copy(
-                    before = (before ?: "") + highlight.substring(0, range.first),
-                    highlight = highlight.substring(range),
-                    after = highlight.substring(range.last) + (after ?: "")
-                )
-            }
+            if (highlight.isNullOrBlank()) return this
+
+            val fixedRange = range.first.coerceIn(0, highlight.length)..range.last.coerceIn(
+                0,
+                highlight.length - 1
+            )
+            return copy(
+                before = (before ?: "") + highlight.substring(0, fixedRange.first),
+                highlight = highlight.substring(fixedRange),
+                after = highlight.substring((fixedRange.last + 1).coerceAtMost(highlight.length)) + (after ?: "")
+            )
         }
 
         public companion object {

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/LocatorTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/LocatorTest.kt
@@ -337,6 +337,131 @@ class LocatorTest {
             ).toJSON()
         )
     }
+
+    @Test fun `substring from a range`() {
+        val text = Locator.Text(
+            before = "before",
+            highlight = "highlight",
+            after = "after"
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "before",
+                highlight = "h",
+                after = "ighlightafter"
+            ),
+            text.substring(0..-1)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "before",
+                highlight = "h",
+                after = "ighlightafter"
+            ),
+            text.substring(0..0)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "beforehigh",
+                highlight = "lig",
+                after = "htafter"
+            ),
+            text.substring(4..6)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "before",
+                highlight = "highlight",
+                after = "after"
+            ),
+            text.substring(0..8)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "beforehighli",
+                highlight = "ght",
+                after = "after"
+            ),
+            text.substring(6..12)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "beforehighligh",
+                highlight = "t",
+                after = "after"
+            ),
+            text.substring(8..12)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "beforehighlight",
+                highlight = "",
+                after = "after"
+            ),
+            text.substring(9..12)
+        )
+    }
+
+    @Test fun `substring from a range with null components`() {
+        assertEquals(
+            Locator.Text(
+                before = "high",
+                highlight = "lig",
+                after = "htafter"
+            ),
+            Locator.Text(
+                before = null,
+                highlight = "highlight",
+                after = "after"
+            ).substring(4..6)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "beforehigh",
+                highlight = "lig",
+                after = "ht"
+            ),
+            Locator.Text(
+                before = "before",
+                highlight = "highlight",
+                after = null
+            ).substring(4..6)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "before",
+                highlight = null,
+                after = "after"
+            ),
+            Locator.Text(
+                before = "before",
+                highlight = null,
+                after = "after"
+            ).substring(4..6)
+        )
+
+        assertEquals(
+            Locator.Text(
+                before = "before",
+                highlight = "",
+                after = "after"
+            ),
+            Locator.Text(
+                before = "before",
+                highlight = "",
+                after = "after"
+            ).substring(4..6)
+        )
+    }
 }
 
 @RunWith(RobolectricTestRunner::class)


### PR DESCRIPTION
* Fix issue when computing a substring of a `Locator.Text`, were the char offsets were incorrect.
* Fix terminating the current TTS task.
    * Sometimes we received events for a previous task, which interrupted the current task too early. I fixed it by checking for the task ID first.