### PR TITLE
Bugfixes for TTS

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIterator.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIterator.kt
@@ -246,16 +246,22 @@ public class HtmlResourceContentIterator internal constructor(
         /** Language of the current segment. */
         private var currentLanguage: String? = null
 
-        /** CSS selector of the current element. */
-        private var currentCssSelector: String? = null
-
         /** LIFO stack of the current element's block ancestors. */
-        private val breadcrumbs = mutableListOf<Element>()
+        private val breadcrumbs = mutableListOf<ParentElement>()
+
+        private data class ParentElement(
+            val element: Element,
+            val cssSelector: String
+        ) {
+            constructor(element: Element) : this(element, element.cssSelector())
+        }
 
         override fun head(node: Node, depth: Int) {
             if (node is Element) {
+                val parent = ParentElement(node)
                 if (node.isBlock) {
-                    breadcrumbs.add(node)
+                    flushText()
+                    breadcrumbs.add(parent)
                 }
 
                 val tag = node.normalName()
@@ -264,7 +270,7 @@ public class HtmlResourceContentIterator internal constructor(
                     baseLocator.copy(
                         locations = Locator.Locations(
                             otherLocations = buildMap {
-                                put("cssSelector", node.cssSelector() as Any)
+                                put("cssSelector", parent.cssSelector as Any)
                             }
                         )
                     )
@@ -339,7 +345,6 @@ public class HtmlResourceContentIterator internal constructor(
 
                     node.isBlock -> {
                         flushText()
-                        currentCssSelector = node.cssSelector()
                     }
                 }
             }
@@ -358,7 +363,7 @@ public class HtmlResourceContentIterator internal constructor(
                 appendNormalisedText(text)
             } else if (node is Element) {
                 if (node.isBlock) {
-                    assert(breadcrumbs.last() == node)
+                    assert(breadcrumbs.last().element == node)
                     flushText()
                     breadcrumbs.removeLast()
                 }
@@ -375,7 +380,9 @@ public class HtmlResourceContentIterator internal constructor(
         private fun flushText() {
             flushSegment()
 
-            if (startIndex == 0 && startElement != null && breadcrumbs.lastOrNull() == startElement) {
+            val parent = breadcrumbs.lastOrNull()
+
+            if (startIndex == 0 && startElement != null && parent?.element == startElement) {
                 startIndex = elements.size
             }
 
@@ -390,8 +397,8 @@ public class HtmlResourceContentIterator internal constructor(
                     locator = baseLocator.copy(
                         locations = Locator.Locations(
                             otherLocations = buildMap {
-                                currentCssSelector?.let {
-                                    put("cssSelector", it as Any)
+                                parent?.let {
+                                    put("cssSelector", it.cssSelector as Any)
                                 }
                             }
                         ),
@@ -423,13 +430,15 @@ public class HtmlResourceContentIterator internal constructor(
                     text = trimmedText + whitespaceSuffix
                 }
 
+                val parent = breadcrumbs.lastOrNull()
+
                 segmentsAcc.add(
                     TextElement.Segment(
                         locator = baseLocator.copy(
                             locations = Locator.Locations(
                                 otherLocations = buildMap {
-                                    currentCssSelector?.let {
-                                        put("cssSelector", it as Any)
+                                    parent?.let {
+                                        put("cssSelector", it.cssSelector as Any)
                                     }
                                 }
                             ),

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIteratorTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIteratorTest.kt
@@ -554,7 +554,7 @@ class HtmlResourceContentIteratorTest {
                 TextElement(
                     locator = locator(
                         progression = 2 / 3.0,
-                        selector = "#c06-para-0019",
+                        selector = "#c06-li-0001 > aside",
                         before = "e just described is very much a waterfall process.\n                        \n                        ",
                         highlight = "Trailing text"
                     ),
@@ -563,11 +563,116 @@ class HtmlResourceContentIteratorTest {
                         Segment(
                             locator = locator(
                                 progression = 2 / 3.0,
-                                selector = "#c06-para-0019",
+                                selector = "#c06-li-0001 > aside",
                                 before = "e just described is very much a waterfall process.\n                        ",
                                 highlight = "Trailing text"
                             ),
                             text = "Trailing text",
+                            attributes = emptyList()
+                        )
+                    ),
+                    attributes = emptyList()
+                )
+            ),
+            iterator(html).elements()
+        )
+    }
+
+    @Test
+    fun `iterating over text nodes located around a nested block element`() = runTest {
+        val html = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+            <body>
+                <div id="a">begin a <div id="b">in b</div> end a</div>
+                <div id="c">in c</div>
+            </body>
+            </html>
+            """
+
+        assertEquals(
+            listOf(
+                TextElement(
+                    locator = locator(
+                        progression = 0.0,
+                        selector = "#a",
+                        highlight = "begin a"
+                    ),
+                    role = TextElement.Role.Body,
+                    segments = listOf(
+                        Segment(
+                            locator = locator(
+                                progression = 0.0,
+                                selector = "#a",
+                                highlight = "begin a"
+                            ),
+                            text = "begin a",
+                            attributes = emptyList()
+                        )
+                    ),
+                    attributes = emptyList()
+                ),
+                TextElement(
+                    locator = locator(
+                        progression = 0.25,
+                        selector = "#b",
+                        before = "begin a ",
+                        highlight = "in b"
+                    ),
+                    role = TextElement.Role.Body,
+                    segments = listOf(
+                        Segment(
+                            locator = locator(
+                                progression = 0.25,
+                                selector = "#b",
+                                before = "begin a ",
+                                highlight = "in b"
+                            ),
+                            text = "in b",
+                            attributes = emptyList()
+                        )
+                    ),
+                    attributes = emptyList()
+                ),
+                TextElement(
+                    locator = locator(
+                        progression = 0.5,
+                        selector = "#a",
+                        before = "begin a in b  ",
+                        highlight = "end a"
+                    ),
+                    role = TextElement.Role.Body,
+                    segments = listOf(
+                        Segment(
+                            locator = locator(
+                                progression = 0.5,
+                                selector = "#a",
+                                before = "begin a in b ",
+                                highlight = "end a"
+                            ),
+                            text = "end a",
+                            attributes = emptyList()
+                        )
+                    ),
+                    attributes = emptyList()
+                ),
+                TextElement(
+                    locator = locator(
+                        progression = 0.75,
+                        selector = "#c",
+                        before = "begin a in b end a",
+                        highlight = "in c"
+                    ),
+                    role = TextElement.Role.Body,
+                    segments = listOf(
+                        Segment(
+                            locator = locator(
+                                progression = 0.75,
+                                selector = "#c",
+                                before = "begin a in b end a",
+                                highlight = "in c"
+                            ),
+                            text = "in c",
                             attributes = emptyList()
                         )
                     ),


### PR DESCRIPTION
* Fix issue highlighting an utterance where the locator contained non-breaking spaces.
    * As we tokenized the sanitized utterance text, the tokenized locator didn't contain the original non breaking spaces. They seem to be relevant for Hypothesis.
    * Solved by keeping non breaking spaces in the sanitized utterance text.
* Fix incorrect CSS selectors when text elements are located around a nested block element.