### PR TITLE
Prevent out of memory errors when sniffing a media type

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/resource/DefaultArchiveFactory.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/resource/DefaultArchiveFactory.kt
@@ -15,6 +15,9 @@ import org.readium.r2.shared.util.MessageError
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.mediatype.MediaTypeRetriever
 
+/**
+ * An [ArchiveFactory] to open local ZIP files with Java's [ZipFile].
+ */
 public class DefaultArchiveFactory(
     private val mediaTypeRetriever: MediaTypeRetriever
 ) : ArchiveFactory {
@@ -28,7 +31,7 @@ public class DefaultArchiveFactory(
             ?.let { open(it) }
             ?: Try.Failure(
                 ArchiveFactory.Error.FormatNotSupported(
-                    MessageError("Resource not supported because file cannot be directly access.")
+                    MessageError("Resource not supported because file cannot be directly accessed.")
                 )
             )
     }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/archive/channel/ChannelZipContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/archive/channel/ChannelZipContainer.kt
@@ -170,7 +170,8 @@ internal class ChannelZipContainer(
 }
 
 /**
- * An [ArchiveFactory] able to open a ZIP archive served through an HTTP server.
+ * An [ArchiveFactory] able to open a ZIP archive served through a stream (e.g. HTTP server,
+ * content URI, etc.).
  */
 public class ChannelZipArchiveFactory(
     private val mediaTypeRetriever: MediaTypeRetriever


### PR DESCRIPTION
This restores [this fix](https://github.com/readium/r2-shared-kotlin/commit/dd0780268539aa2376f89c84a7ab61fed83d62a5#diff-be198afd4545d50e95947243a040c05085a51ae67be0a16f45851106955df941) which was lost during the media type refactoring.