### PR TITLE
Fix crash with `ChannelZipContainer` before API 26

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/archive/channel/compress/utils/IOUtils.java
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/archive/channel/compress/utils/IOUtils.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.file.LinkOption;
 
 /**
  * Utility functions
@@ -37,13 +36,6 @@ public final class IOUtils {
 
     private static final int COPY_BUF_SIZE = 8024;
     private static final int SKIP_BUF_SIZE = 4096;
-
-    /**
-     * Empty array of type {@link LinkOption}.
-     *
-     * @since 1.21
-     */
-    public static final LinkOption[] EMPTY_LINK_OPTIONS = {};
 
     // This buffer does not need to be synchronized because it is write only; the contents are ignored
     // Does not affect Immutability


### PR DESCRIPTION
[`LinkOption` is only available since API 26](https://developer.android.com/reference/java/nio/file/LinkOption), so `ChannelZipContainer` crashed with:

```
java.lang.NoClassDefFoundError: Failed resolution of: [Ljava/nio/file/LinkOption;
	at org.readium.r2.shared.util.archive.channel.compress.utils.IOUtils.<clinit>(IOUtils.java:46)
	at org.readium.r2.shared.util.archive.channel.compress.archivers.zip.ZipFile.tryToLocateSignature(ZipFile.java:1392)
	at org.readium.r2.shared.util.archive.channel.compress.archivers.zip.ZipFile.positionAtEndOfCentralDirectoryRecord(ZipFile.java:1071)
	at org.readium.r2.shared.util.archive.channel.compress.archivers.zip.ZipFile.positionAtCentralDirectory(ZipFile.java:941)
	at org.readium.r2.shared.util.archive.channel.compress.archivers.zip.ZipFile.populateFromCentralDirectory(ZipFile.java:912)
	at org.readium.r2.shared.util.archive.channel.compress.archivers.zip.ZipFile.<init>(ZipFile.java:526)
	at org.readium.r2.shared.util.archive.channel.compress.archivers.zip.ZipFile.<init>(ZipFile.java:459)
	at org.readium.r2.shared.util.archive.channel.ChannelZipArchiveFactory.create(ChannelZipContainer.kt:191)
	at org.readium.r2.shared.resource.CompositeArchiveFactory.create(Factories.kt:172)
	at org.readium.r2.shared.asset.AssetRetriever.retrieve(AssetRetriever.kt:259)
	at org.readium.r2.testapp.domain.Bookshelf.addBook(Bookshelf.kt:126)
	at org.readium.r2.testapp.domain.Bookshelf.addBookFeedback(Bookshelf.kt:116)
	at org.readium.r2.testapp.domain.Bookshelf.addBookFeedback$default(Bookshelf.kt:112)
	at org.readium.r2.testapp.domain.Bookshelf$addPublicationFromStorage$1.invokeSuspend(Bookshelf.kt:108)
```

Luckily, `LinkOption` was not really used, so I just removed the references.

To reproduce, use "Read from shared storage" on an API 25 emulator.