### PR TITLE
Fix crash in `CoroutineQueue`

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/CoroutineQueue.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/CoroutineQueue.kt
@@ -31,6 +31,8 @@ public class CoroutineQueue(
     private val scope: CoroutineScope =
         CoroutineScope(dispatcher + SupervisorJob())
 
+    private val tasks: Channel<Task<*>> = Channel(Channel.UNLIMITED)
+
     init {
         scope.launch {
             for (task in tasks) {
@@ -78,8 +80,6 @@ public class CoroutineQueue(
     public fun cancel(cause: CancellationException? = null) {
         scope.cancel(cause)
     }
-
-    private val tasks: Channel<Task<*>> = Channel(Channel.UNLIMITED)
 
     private class Task<T>(
         val task: suspend () -> T,

--- a/test-app/src/main/java/org/readium/r2/testapp/utils/CoroutineQueue.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/utils/CoroutineQueue.kt
@@ -29,6 +29,8 @@ class CoroutineQueue(
     private val scope: CoroutineScope =
         CoroutineScope(dispatcher + SupervisorJob())
 
+    private val tasks: Channel<Task<*>> = Channel(Channel.UNLIMITED)
+
     init {
         scope.launch {
             for (task in tasks) {
@@ -76,8 +78,6 @@ class CoroutineQueue(
     fun cancel(cause: CancellationException? = null) {
         scope.cancel(cause)
     }
-
-    private val tasks: Channel<Task<*>> = Channel(Channel.UNLIMITED)
 
     private class Task<T>(
         val task: suspend () -> T,


### PR DESCRIPTION
`CoroutineQueue` could crash during initialization if the tasks coroutine executes before the object is fully initialized. Moving the `tasks` property above `init` should fix the issue.

```
java.lang.NullPointerException: Attempt to invoke interface method 'kotlinx.coroutines.channels.ChannelIterator kotlinx.coroutines.channels.Channel.iterator()' on a null object reference
    at org.readium.r2.shared.util.CoroutineQueue$1.invokeSuspend(CoroutineQueue.kt:36)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
```