### PR TITLE
Additional copy preventions for protected publications

### DIFF
--- a/readium/adapters/pspdfkit/navigator/src/main/java/org/readium/adapter/pspdfkit/navigator/PsPdfKitDocumentFragment.kt
+++ b/readium/adapters/pspdfkit/navigator/src/main/java/org/readium/adapter/pspdfkit/navigator/PsPdfKitDocumentFragment.kt
@@ -283,11 +283,16 @@ public class PsPdfKitDocumentFragment internal constructor(
             return listener?.onTap(pagePosition) ?: false
         }
 
-        private val allowedTextSelectionItems = listOf(
-            com.pspdfkit.R.id.pspdf__text_selection_toolbar_item_share,
-            com.pspdfkit.R.id.pspdf__text_selection_toolbar_item_copy,
-            com.pspdfkit.R.id.pspdf__text_selection_toolbar_item_speak
-        )
+        private val allowedTextSelectionItems: List<Int> by lazy {
+            buildList {
+                add(com.pspdfkit.R.id.pspdf__text_selection_toolbar_item_speak)
+
+                if (!publication.isProtected) {
+                    add(com.pspdfkit.R.id.pspdf__text_selection_toolbar_item_share)
+                    add(com.pspdfkit.R.id.pspdf__text_selection_toolbar_item_copy)
+                }
+            }
+        }
 
         override fun onPrepareTextSelectionPopupToolbar(toolbar: PdfTextSelectionPopupToolbar) {
             // Makes sure only the menu items in `allowedTextSelectionItems` will be visible.

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/NavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/NavigatorFragment.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.navigator
+
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.fragment.app.Fragment
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.isProtected
+import org.readium.r2.shared.publication.services.isRestricted
+
+public abstract class NavigatorFragment internal constructor(
+    override val publication: Publication
+) : Fragment(), Navigator {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        require(!publication.isRestricted) { "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection." }
+
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        // Prevent screenshots and text selection from the task switcher for protected publications.
+        if (publication.isProtected) {
+            activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        if (publication.isProtected) {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+}

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -47,6 +47,7 @@ import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.DecorationId
 import org.readium.r2.navigator.ExperimentalDecorator
 import org.readium.r2.navigator.HyperlinkNavigator
+import org.readium.r2.navigator.NavigatorFragment
 import org.readium.r2.navigator.OverflowNavigator
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.R2BasicWebView
@@ -85,7 +86,6 @@ import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.presentation
-import org.readium.r2.shared.publication.services.isRestricted
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.mediatype.MediaType
@@ -106,7 +106,7 @@ public typealias JavascriptInterfaceFactory = (resource: Link) -> Any?
  */
 @OptIn(ExperimentalDecorator::class, ExperimentalReadiumApi::class, DelicateReadiumApi::class)
 public class EpubNavigatorFragment internal constructor(
-    override val publication: Publication,
+    publication: Publication,
     private val initialLocator: Locator?,
     readingOrder: List<Link>?,
     private val initialPreferences: EpubPreferences,
@@ -115,7 +115,7 @@ public class EpubNavigatorFragment internal constructor(
     epubLayout: EpubLayout,
     private val defaults: EpubDefaults,
     configuration: Configuration
-) : Fragment(),
+) : NavigatorFragment(publication),
     OverflowNavigator,
     SelectableNavigator,
     DecorableNavigator,
@@ -260,10 +260,6 @@ public class EpubNavigatorFragment internal constructor(
     }
 
     public interface Listener : OverflowNavigator.Listener, HyperlinkNavigator.Listener
-
-    init {
-        require(!publication.isRestricted) { "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection." }
-    }
 
     // Configurable
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/image/ImageNavigatorFragment.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentFactory
 import androidx.viewpager.widget.ViewPager
@@ -21,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.runBlocking
+import org.readium.r2.navigator.NavigatorFragment
 import org.readium.r2.navigator.OverflowNavigator
 import org.readium.r2.navigator.SimplePresentation
 import org.readium.r2.navigator.VisualNavigator
@@ -44,7 +44,6 @@ import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 import org.readium.r2.shared.publication.indexOfFirstWithHref
-import org.readium.r2.shared.publication.services.isRestricted
 import org.readium.r2.shared.publication.services.positions
 
 /**
@@ -52,16 +51,12 @@ import org.readium.r2.shared.publication.services.positions
  */
 @OptIn(ExperimentalReadiumApi::class, DelicateReadiumApi::class)
 public class ImageNavigatorFragment private constructor(
-    override val publication: Publication,
+    publication: Publication,
     private val initialLocator: Locator? = null,
     internal val listener: Listener? = null
-) : Fragment(), OverflowNavigator {
+) : NavigatorFragment(publication), OverflowNavigator {
 
     public interface Listener : VisualNavigator.Listener
-
-    init {
-        require(!publication.isRestricted) { "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection." }
-    }
 
     internal lateinit var positions: List<Locator>
     internal lateinit var resourcePager: R2ViewPager

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pdf/PdfNavigatorFragment.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.readium.r2.navigator.NavigatorFragment
 import org.readium.r2.navigator.OverflowNavigator
 import org.readium.r2.navigator.R
 import org.readium.r2.navigator.VisualNavigator
@@ -40,7 +41,6 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
-import org.readium.r2.shared.publication.services.isRestricted
 import org.readium.r2.shared.util.mediatype.MediaType
 
 /**
@@ -54,12 +54,12 @@ import org.readium.r2.shared.util.mediatype.MediaType
 @ExperimentalReadiumApi
 @OptIn(DelicateReadiumApi::class)
 public class PdfNavigatorFragment<S : Configurable.Settings, P : Configurable.Preferences<P>> internal constructor(
-    override val publication: Publication,
+    publication: Publication,
     private val initialLocator: Locator? = null,
     private val initialPreferences: P,
     private val listener: Listener?,
     private val pdfEngineProvider: PdfEngineProvider<S, P, *>
-) : Fragment(), VisualNavigator, OverflowNavigator, Configurable<S, P> {
+) : NavigatorFragment(publication), VisualNavigator, OverflowNavigator, Configurable<S, P> {
 
     public interface Listener : VisualNavigator.Listener
 
@@ -94,8 +94,6 @@ public class PdfNavigatorFragment<S : Configurable.Settings, P : Configurable.Pr
     }
 
     init {
-        require(!publication.isRestricted) { "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection." }
-
         require(
             publication.readingOrder.count() == 1 &&
                 publication.readingOrder.first().mediaType?.matches(MediaType.PDF) == true


### PR DESCRIPTION
* Disable PSPDFKit's Share action with protected publications.
    * **Copy** was already [disabled here](https://github.com/readium/kotlin-toolkit/blob/17423811fa962ac3da8f0ecd58b69c0e28c1a2a7/readium/adapters/pspdfkit/navigator/src/main/java/org/readium/adapter/pspdfkit/navigator/PsPdfKitDocumentFragment.kt#L223-L225) but this didn't remove the Share text selection action.
* Prevent screenshots and text selection from the task switcher for protected publications.