### PR TITLE
Simplify the `PublicationOpener` by adding a `DefaultPublicationParser`

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/OptIn.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/OptIn.kt
@@ -51,19 +51,6 @@ public annotation class DelicateReadiumApi
 
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,
-    message = "Support for PDF is still experimental. The API may be changed in the future without notice."
-)
-@Retention(AnnotationRetention.BINARY)
-@Target(
-    AnnotationTarget.CLASS,
-    AnnotationTarget.FUNCTION,
-    AnnotationTarget.TYPEALIAS,
-    AnnotationTarget.PROPERTY
-)
-public annotation class PdfSupport
-
-@RequiresOptIn(
-    level = RequiresOptIn.Level.WARNING,
     message = "Support for SearchService is still experimental. The API may be changed in the future without notice."
 )
 @Retention(AnnotationRetention.BINARY)

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/PublicationParser.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/PublicationParser.kt
@@ -55,19 +55,19 @@ public interface PublicationParser {
  * Default implementation of [PublicationParser] handling all the publication formats supported by
  * Readium.
  *
- * @param parsers Parsers used to open a publication, in addition to the default parsers. They take precedence over the default ones.
+ * @param additionalParsers Parsers used to open a publication, in addition to the default parsers. They take precedence over the default ones.
  * @param httpClient Service performing HTTP requests.
  * @param pdfFactory Parses a PDF document, optionally protected by password.
  * @param assetOpener Opens assets in case of indirection.
  */
 public class DefaultPublicationParser(
     context: Context,
-    parsers: List<PublicationParser> = emptyList(),
+    additionalParsers: List<PublicationParser> = emptyList(),
     private val httpClient: HttpClient,
     pdfFactory: PdfDocumentFactory<*>?,
     assetOpener: AssetOpener
-) : CompositePublicationParser(
-    parsers + listOfNotNull(
+) : PublicationParser by CompositePublicationParser(
+    additionalParsers + listOfNotNull(
         EpubParser(),
         pdfFactory?.let { PdfParser(context, it) },
         ReadiumWebPubParser(context, httpClient, pdfFactory),
@@ -80,7 +80,7 @@ public class DefaultPublicationParser(
  * A composite [PublicationParser] which tries several parsers until it finds one which supports
  * the asset.
  */
-public open class CompositePublicationParser(
+public class CompositePublicationParser(
     private val parsers: List<PublicationParser>
 ) : PublicationParser {
 

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/pdf/PdfParser.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/pdf/PdfParser.kt
@@ -8,7 +8,6 @@ package org.readium.r2.streamer.parser.pdf
 
 import android.content.Context
 import org.readium.r2.shared.ExperimentalReadiumApi
-import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.services.InMemoryCacheService
 import org.readium.r2.shared.publication.services.InMemoryCoverService
@@ -27,7 +26,6 @@ import org.readium.r2.streamer.parser.PublicationParser
 /**
  * Parses a PDF file into a Readium [Publication].
  */
-@PdfSupport
 @OptIn(ExperimentalReadiumApi::class)
 public class PdfParser(
     context: Context,

--- a/test-app/src/main/java/org/readium/r2/testapp/Readium.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/Readium.kt
@@ -25,6 +25,7 @@ import org.readium.r2.shared.util.http.HttpResourceFactory
 import org.readium.r2.shared.util.resource.CompositeResourceFactory
 import org.readium.r2.shared.util.zip.ZipArchiveOpener
 import org.readium.r2.streamer.PublicationOpener
+import org.readium.r2.streamer.parser.DefaultPublicationParser
 
 /**
  * Holds the shared Readium objects and services used by the app.
@@ -70,15 +71,17 @@ class Readium(context: Context) {
     )
 
     /**
-     * The PublicationFactory is used to parse and open publications.
+     * The PublicationFactory is used to open publications.
      */
     val publicationOpener = PublicationOpener(
-        context,
-        contentProtections = contentProtections,
-        assetOpener = assetOpener,
-        httpClient = httpClient,
-        // Only required if you want to support PDF files using the PDFium adapter.
-        pdfFactory = PdfiumDocumentFactory(context)
+        parser = DefaultPublicationParser(
+            context,
+            assetOpener = assetOpener,
+            httpClient = httpClient,
+            // Only required if you want to support PDF files using the PDFium adapter.
+            pdfFactory = PdfiumDocumentFactory(context)
+        ),
+        contentProtections = contentProtections
     )
 
     fun onLcpDialogAuthenticationParentAttached(view: View) {


### PR DESCRIPTION
Adds a composite `PublicationParser` to remove the construction arguments required by `PublicationOpener` to create the parsers.