### PR TITLE
Minor fixes

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/VisualNavigator.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/VisualNavigator.kt
@@ -24,7 +24,7 @@ import org.readium.r2.shared.publication.ReadingProgression as PublicationReadin
 public interface VisualNavigator : Navigator {
 
     @Deprecated(
-        "Moved to DirectionalNavigator",
+        "Renamed to OverflowableNavigator.Overflow",
         level = DeprecationLevel.ERROR
     )
     @OptIn(ExperimentalReadiumApi::class)
@@ -126,7 +126,7 @@ public interface VisualNavigator : Navigator {
      * Moves to the next content portion (eg. page) in the reading progression direction.
      */
     @Deprecated(
-        "Moved to DirectionalNavigator",
+        "Moved to OverflowableNavigator",
         level = DeprecationLevel.ERROR
     )
     public fun goForward(animated: Boolean = false, completion: () -> Unit = {}): Boolean
@@ -135,7 +135,7 @@ public interface VisualNavigator : Navigator {
      * Moves to the previous content portion (eg. page) in the reading progression direction.
      */
     @Deprecated(
-        "Moved to DirectionalNavigator",
+        "Moved to OverflowableNavigator",
         level = DeprecationLevel.ERROR
     )
     public fun goBackward(animated: Boolean = false, completion: () -> Unit = {}): Boolean

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaSessionNavigator.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/media/MediaSessionNavigator.kt
@@ -208,7 +208,7 @@ public class MediaSessionNavigator(
         return go(locator, animated, completion)
     }
 
-    public fun goForward(animated: Boolean, completion: () -> Unit): Boolean {
+    public fun goForward(animated: Boolean = true, completion: () -> Unit = {}): Boolean {
         if (!isActive) return false
 
         seekRelative(skipForwardInterval)
@@ -216,7 +216,7 @@ public class MediaSessionNavigator(
         return true
     }
 
-    public fun goBackward(animated: Boolean, completion: () -> Unit): Boolean {
+    public fun goBackward(animated: Boolean = true, completion: () -> Unit = {}): Boolean {
         if (!isActive) return false
 
         seekRelative(-skipBackwardInterval)


### PR DESCRIPTION
* Fixed deprecated notices
* Restore default parameters for `MediaNavigator.goForward` and `goBackward` APIs.
* Prevent crash in `ForegroundDownloadManager` when the download folder doesn't exist.