### PR TITLE
Implement sniffing of CSS and JS files

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt
@@ -34,8 +34,30 @@ object Sniffers {
      */
     val all: List<Sniffer> = listOf(
         ::xhtml, ::html, ::opds, ::lcpLicense, ::bitmap, ::webpub, ::w3cWPUB, ::epub, ::lpf, ::archive,
-        ::pdf, ::json
+        ::pdf, ::json, ::css, ::javascript
     )
+
+    /**
+     * Sniffs a CSS file.
+     */
+
+    suspend fun css(context: SnifferContext): MediaType? {
+        if (context.hasFileExtension("css") || context.hasMediaType("text/css")) {
+            return MediaType.CSS
+        }
+        return null
+    }
+
+    /**
+     * Sniffs a JavaScript file.
+     */
+
+    suspend fun javascript(context: SnifferContext): MediaType? {
+        if (context.hasFileExtension("js") || context.hasMediaType("text/javascript", "application/javascript")) {
+            return MediaType.JAVASCRIPT
+        }
+        return null
+    }
 
     /**
      * Sniffs an XHTML document.

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/mediatype/SnifferTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/mediatype/SnifferTest.kt
@@ -312,4 +312,17 @@ class SnifferTest {
         )!!
         assertEquals(png, MediaType.ofFile(fixtures.fileAt("png.unknown")))
     }
+
+    @Test
+    fun `sniff CSS`() = runBlocking {
+        assertEquals(MediaType.CSS, MediaType.of(fileExtension = "css"))
+        assertEquals(MediaType.CSS, MediaType.of(mediaType = "text/css"))
+    }
+
+    @Test
+    fun `sniff JS`() = runBlocking {
+        assertEquals(MediaType.JAVASCRIPT, MediaType.of(fileExtension = "js"))
+        assertEquals(MediaType.JAVASCRIPT, MediaType.of(mediaType = "text/javascript"))
+        assertEquals(MediaType.JAVASCRIPT, MediaType.of(mediaType = "application/javascript"))
+    }
 }


### PR DESCRIPTION
This adds a couple of media type sniffers that can guess CSS and JS files from their content types and/or file extensions.

I added them as the lowest priority they could be.