### PR TITLE
Implement sniffing of CSS and JS files

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/asset/Defaults.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/asset/Defaults.kt
@@ -14,11 +14,13 @@ import org.readium.r2.shared.util.file.FileResourceFactory
 import org.readium.r2.shared.util.format.ArchiveSniffer
 import org.readium.r2.shared.util.format.AudioSniffer
 import org.readium.r2.shared.util.format.BitmapSniffer
+import org.readium.r2.shared.util.format.CssSniffer
 import org.readium.r2.shared.util.format.CompositeFormatSniffer
 import org.readium.r2.shared.util.format.EpubDrmSniffer
 import org.readium.r2.shared.util.format.EpubSniffer
 import org.readium.r2.shared.util.format.FormatSniffer
 import org.readium.r2.shared.util.format.HtmlSniffer
+import org.readium.r2.shared.util.format.JavaScriptSniffer
 import org.readium.r2.shared.util.format.JsonSniffer
 import org.readium.r2.shared.util.format.LcpLicenseSniffer
 import org.readium.r2.shared.util.format.LpfSniffer
@@ -92,5 +94,7 @@ public class DefaultFormatSniffer(
     LcpLicenseSniffer,
     EpubDrmSniffer,
     W3cWpubSniffer,
-    RwpmSniffer
+    RwpmSniffer,
+    CssSniffer,
+    JavaScriptSniffer
 )

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/asset/Defaults.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/asset/Defaults.kt
@@ -14,8 +14,8 @@ import org.readium.r2.shared.util.file.FileResourceFactory
 import org.readium.r2.shared.util.format.ArchiveSniffer
 import org.readium.r2.shared.util.format.AudioSniffer
 import org.readium.r2.shared.util.format.BitmapSniffer
-import org.readium.r2.shared.util.format.CssSniffer
 import org.readium.r2.shared.util.format.CompositeFormatSniffer
+import org.readium.r2.shared.util.format.CssSniffer
 import org.readium.r2.shared.util.format.EpubDrmSniffer
 import org.readium.r2.shared.util.format.EpubSniffer
 import org.readium.r2.shared.util.format.FormatSniffer

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/format/Format.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/format/Format.kt
@@ -137,3 +137,11 @@ public object Opds1EntrySpecification : Specification
 public object Opds2CatalogSpecification : Specification
 public object Opds2PublicationSpecification : Specification
 public object OpdsAuthenticationSpecification : Specification
+
+/*
+ * Language specifications
+ */
+
+public object JavaScriptSpecification : Specification
+
+public object CssSpecification : Specification

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/format/Sniffers.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/format/Sniffers.kt
@@ -1260,6 +1260,55 @@ public object EpubDrmSniffer : FormatSniffer {
     }
 }
 
+/**
+ * Sniffs CSS.
+ */
+
+public object CssSniffer : FormatSniffer {
+    override fun sniffHints(format: Format, hints: FormatHints): Format {
+        if (format.hasAnySpecification()) {
+            return format
+        }
+
+        if (hints.hasFileExtension("css") ||
+            hints.hasMediaType("text/css")
+        ) {
+            return Format(
+                specification = FormatSpecification(CssSpecification),
+                mediaType = MediaType.CSS,
+                fileExtension = FileExtension("css")
+            )
+        }
+
+        return format
+    }
+}
+
+/**
+ * Sniffs JavaScript.
+ */
+
+public object JavaScriptSniffer : FormatSniffer {
+    override fun sniffHints(format: Format, hints: FormatHints): Format {
+        if (format.hasAnySpecification()) {
+            return format
+        }
+
+        if (hints.hasFileExtension("js") ||
+            hints.hasMediaType("text/javascript") ||
+            hints.hasMediaType("application/javascript")
+        ) {
+            return Format(
+                specification = FormatSpecification(JavaScriptSpecification),
+                mediaType = MediaType.JAVASCRIPT,
+                fileExtension = FileExtension("js")
+            )
+        }
+
+        return format
+    }
+}
+
 private suspend fun Readable.canReadWholeBlob() =
     length().getOrDefault(0) < 5 * 1000 * 1000
 

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/asset/AssetSnifferTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/asset/AssetSnifferTest.kt
@@ -20,6 +20,7 @@ import org.readium.r2.shared.util.data.EmptyContainer
 import org.readium.r2.shared.util.file.FileResource
 import org.readium.r2.shared.util.format.AvifSpecification
 import org.readium.r2.shared.util.format.BmpSpecification
+import org.readium.r2.shared.util.format.CssSpecification
 import org.readium.r2.shared.util.format.EpubSpecification
 import org.readium.r2.shared.util.format.Format
 import org.readium.r2.shared.util.format.FormatHints
@@ -28,6 +29,7 @@ import org.readium.r2.shared.util.format.GifSpecification
 import org.readium.r2.shared.util.format.HtmlSpecification
 import org.readium.r2.shared.util.format.InformalAudiobookSpecification
 import org.readium.r2.shared.util.format.InformalComicSpecification
+import org.readium.r2.shared.util.format.JavaScriptSpecification
 import org.readium.r2.shared.util.format.JpegSpecification
 import org.readium.r2.shared.util.format.JsonSpecification
 import org.readium.r2.shared.util.format.JxlSpecification
@@ -838,6 +840,46 @@ class AssetSnifferTest {
                 resource = StringResource("""{"title": "Message"}"""),
                 hints = FormatHints(mediaType = MediaType("application/problem+json")!!)
             ).checkSuccess()
+        )
+    }
+
+    private val cssFormat = Format(
+        specification = FormatSpecification(CssSpecification),
+        mediaType = MediaType.CSS,
+        fileExtension = FileExtension("css")
+    )
+
+    @Test
+    fun `sniff CSS`() = runBlocking {
+        assertEquals(
+            cssFormat,
+            sniffer.sniffFileExtension("css").checkSuccess()
+        )
+        assertEquals(
+            cssFormat,
+            sniffer.sniffMediaType("text/css").checkSuccess()
+        )
+    }
+
+    private val jsFormat = Format(
+        specification = FormatSpecification(JavaScriptSpecification),
+        mediaType = MediaType.JAVASCRIPT,
+        fileExtension = FileExtension("js")
+    )
+
+    @Test
+    fun `sniff JavaScript`() = runBlocking {
+        assertEquals(
+            jsFormat,
+            sniffer.sniffFileExtension("js").checkSuccess()
+        )
+        assertEquals(
+            jsFormat,
+            sniffer.sniffMediaType("text/javascript").checkSuccess()
+        )
+        assertEquals(
+            jsFormat,
+            sniffer.sniffMediaType("application/javascript").checkSuccess()
         )
     }
 }

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/format/DefaultSniffersTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/format/DefaultSniffersTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.readium.r2.shared.util.FileExtension
 import org.readium.r2.shared.util.Url
-import org.readium.r2.shared.util.asset.DefaultFormatSniffer
 import org.readium.r2.shared.util.checkSuccess
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.robolectric.RobolectricTestRunner
@@ -114,29 +113,5 @@ class DefaultSniffersTest {
                 )
             ).checkSuccess()
         )
-    }
-
-    private val cssFormat = Format(
-        specification = FormatSpecification(CssSpecification),
-        mediaType = MediaType.CSS,
-        fileExtension = FileExtension("css")
-    )
-
-    @Test
-    fun `Sniff CSS`() = runBlocking {
-        val sniffer = DefaultFormatSniffer()
-        assertEquals(cssFormat, sniffer.sniffHints(format = cssFormat, hints = FormatHints()))
-    }
-
-    private val jsFormat = Format(
-        specification = FormatSpecification(JavaScriptSpecification),
-        mediaType = MediaType.JAVASCRIPT,
-        fileExtension = FileExtension("js")
-    )
-
-    @Test
-    fun `Sniff JS`() = runBlocking {
-        val sniffer = DefaultFormatSniffer()
-        assertEquals(jsFormat, sniffer.sniffHints(format = jsFormat, hints = FormatHints()))
     }
 }

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/format/DefaultSniffersTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/format/DefaultSniffersTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.readium.r2.shared.util.FileExtension
 import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.asset.DefaultFormatSniffer
 import org.readium.r2.shared.util.checkSuccess
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.robolectric.RobolectricTestRunner
@@ -113,5 +114,29 @@ class DefaultSniffersTest {
                 )
             ).checkSuccess()
         )
+    }
+
+    private val cssFormat = Format(
+        specification = FormatSpecification(CssSpecification),
+        mediaType = MediaType.CSS,
+        fileExtension = FileExtension("css")
+    )
+
+    @Test
+    fun `Sniff CSS`() = runBlocking {
+        val sniffer = DefaultFormatSniffer()
+        assertEquals(cssFormat, sniffer.sniffHints(format = cssFormat, hints = FormatHints()))
+    }
+
+    private val jsFormat = Format(
+        specification = FormatSpecification(JavaScriptSpecification),
+        mediaType = MediaType.JAVASCRIPT,
+        fileExtension = FileExtension("js")
+    )
+
+    @Test
+    fun `Sniff JS`() = runBlocking {
+        val sniffer = DefaultFormatSniffer()
+        assertEquals(jsFormat, sniffer.sniffHints(format = jsFormat, hints = FormatHints()))
     }
 }


### PR DESCRIPTION
This adds a couple of media type sniffers that can guess CSS and JS files from their content types and/or file extensions.