### PR TITLE
Cleanup Gradle and Version files, fix Dokka

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "READIUM_VERSION=`git describe --tag --match [0-9]* --abbrev=0`" >> $GITHUB_ENV
 
       - name: Run Dokka
-        run: ./gradlew dokkaGfmMultiModule
+        run: ./gradlew :dokkaGfmMultiModule
 
       - name: Copy README.md into docs to replace Dokka index.md
         run: cp README.md index.md

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,33 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="SwiftRedundantAttribute" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="SwiftRedundantReturn" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="SwiftUnnecessaryParentheses" enabled="false" level="INFORMATION" enabled_by_default="false" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,15 +12,14 @@ plugins {
 }
 
 subprojects {
+    if (name != "test-app") {
+        apply(plugin = "org.jetbrains.dokka")
+    }
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     ktlint {
         android.set(true)
     }
-}
-
-tasks.register("clean", Delete::class).configure {
-    delete(rootProject.buildDir)
 }
 
 tasks.register("cleanDocs", Delete::class).configure {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 
 kotlin = "1.9.22"
-agp = "8.2.1"
+agp = "8.2.2"
 gradle-maven-publish-plugin = "0.27.0"
 
-accompanist = "0.32.0"
+accompanist = "0.34.0"
 
 androidx-activity = "1.8.2"
 androidx-appcompat = "1.6.1"
@@ -13,12 +13,12 @@ androidx-cardview = "1.0.0"
 # Make sure to align with the Kotlin version
 # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 androidx-compose-compiler = "1.5.8"
-androidx-compose-animation = "1.5.4"
-androidx-compose-foundation = "1.5.4"
-androidx-compose-material = "1.5.4"
+androidx-compose-animation = "1.6.0"
+androidx-compose-foundation = "1.6.0"
+androidx-compose-material = "1.6.0"
 androidx-compose-material3 = "1.1.2"
-androidx-compose-runtime = "1.5.4"
-androidx-compose-ui = "1.5.4"
+androidx-compose-runtime = "1.6.0"
+androidx-compose-ui = "1.6.0"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.12.0"
 androidx-datastore = "1.0.0"
@@ -30,15 +30,15 @@ androidx-lifecycle = "2.7.0"
 androidx-lifecycle-extensions = "2.2.0"
 androidx-media = "1.7.0"
 androidx-media2 = "1.3.0"
-androidx-media3 = "1.2.0"
+androidx-media3 = "1.2.1"
 androidx-navigation = "2.7.6"
 androidx-paging = "3.2.1"
 androidx-recyclerview = "1.3.2"
 androidx-room = "2.6.1"
 androidx-viewpager2 = "1.0.0"
-androidx-webkit = "1.9.0"
+androidx-webkit = "1.10.0"
 
-assertj = "3.25.1"
+assertj = "3.25.2"
 
 dokka = "1.9.10"
 
@@ -83,6 +83,7 @@ androidx-compose-foundation = { group = "androidx.compose.foundation", name = "f
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "androidx-compose-material" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidx-compose-material3" }
 androidx-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "androidx-compose-material" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "androidx-compose-runtime" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "androidx-compose-ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "androidx-compose-ui" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
@@ -137,7 +138,6 @@ kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", vers
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
-kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 
@@ -155,17 +155,19 @@ plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 plugin-maven-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradle-maven-publish-plugin" }
 
 [plugins]
+
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 [bundles]
-compose = ["androidx-compose-activity", "androidx-compose-animation", "androidx-compose-foundation", "androidx-compose-material", "androidx-compose-material3", "androidx-compose-material-icons", "androidx-compose-ui", "androidx-compose-ui-tooling"]
-coroutines = ["kotlinx-coroutines-core", "kotlinx-coroutines-android"]
+
+compose = ["androidx-compose-activity", "androidx-compose-animation", "androidx-compose-foundation", "androidx-compose-material", "androidx-compose-material3", "androidx-compose-material-icons", "androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling"]
 exoplayer = ["google-exoplayer-core", "google-exoplayer-ui", "google-exoplayer-mediasession", "google-exoplayer-workmanager", "google-exoplayer-extension-media2"]
 lifecycle = ["androidx-lifecycle-common", "androidx-lifecycle-extensions", "androidx-lifecycle-livedata", "androidx-lifecycle-runtime", "androidx-lifecycle-viewmodel", "androidx-lifecycle-vmsavedstate", "androidx-lifecycle-viewmodel-compose"]
-media2 = ["androidx-media2-session", "androidx-media2-player"]
+media2 = ["androidx-media2-session", "androidx-media2-player", "google-exoplayer-core", "google-exoplayer-extension-media2"]
 media3 = ["androidx-media3-session", "androidx-media3-common", "androidx-media3-exoplayer"]
 navigation = ["androidx-navigation-fragment", "androidx-navigation-ui"]
 room = ["androidx-room-runtime", "androidx-room-ktx"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,7 +158,6 @@ plugin-maven-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", 
 
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 

--- a/readium/adapters/exoplayer/audio/build.gradle.kts
+++ b/readium/adapters/exoplayer/audio/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.androidx.media3.common)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.timber)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 
     // Tests

--- a/readium/adapters/pdfium/document/build.gradle.kts
+++ b/readium/adapters/pdfium/document/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.pdfium)
     implementation(libs.timber)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
 
     testImplementation(libs.junit)
 

--- a/readium/adapters/pdfium/navigator/build.gradle.kts
+++ b/readium/adapters/pdfium/navigator/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     api(libs.pdf.viewer)
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.timber)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit)

--- a/readium/adapters/pspdfkit/document/build.gradle.kts
+++ b/readium/adapters/pspdfkit/document/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.timber)
     implementation(libs.pspdfkit)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
 
     testImplementation(libs.junit)
 

--- a/readium/adapters/pspdfkit/navigator/build.gradle.kts
+++ b/readium/adapters/pspdfkit/navigator/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.timber)
     implementation(libs.pspdfkit)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit)

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
 
     api(project(":readium:readium-shared"))
 

--- a/readium/navigator-media2/build.gradle.kts
+++ b/readium/navigator-media2/build.gradle.kts
@@ -20,14 +20,11 @@ dependencies {
     api(project(":readium:readium-shared"))
     api(project(":readium:readium-navigator"))
 
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
 
     implementation(libs.timber)
 
     implementation(libs.bundles.media2)
-
-    implementation(libs.google.exoplayer.core)
-    implementation(libs.google.exoplayer.extension.media2)
 
     testImplementation(libs.junit)
 

--- a/readium/navigator/build.gradle.kts
+++ b/readium/navigator/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation(libs.google.material)
     implementation(libs.timber)
     implementation(libs.joda.time)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.jsoup)
 

--- a/readium/navigators/media/audio/build.gradle.kts
+++ b/readium/navigators/media/audio/build.gradle.kts
@@ -24,5 +24,5 @@ dependencies {
 
     implementation(libs.androidx.core)
     implementation(libs.timber)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
 }

--- a/readium/navigators/media/common/build.gradle.kts
+++ b/readium/navigators/media/common/build.gradle.kts
@@ -18,5 +18,5 @@ dependencies {
 
     implementation(libs.androidx.media3.common)
     implementation(libs.timber)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
 }

--- a/readium/navigators/media/tts/build.gradle.kts
+++ b/readium/navigators/media/tts/build.gradle.kts
@@ -20,6 +20,6 @@ dependencies {
     implementation(libs.androidx.media3.session)
 
     implementation(libs.timber)
-    implementation(libs.bundles.coroutines)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 }

--- a/readium/opds/build.gradle.kts
+++ b/readium/opds/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.timber)
     implementation(libs.joda.time)
-    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
 
     // Tests
     testImplementation(libs.junit)

--- a/readium/shared/build.gradle.kts
+++ b/readium/shared/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.joda.time)
     implementation(libs.kotlin.reflect)
-    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.jsoup)
 

--- a/readium/streamer/build.gradle.kts
+++ b/readium/streamer/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
         exclude(module = "support-v4")
     }
     implementation(libs.joda.time)
-    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
 
     // Tests
     testImplementation(libs.junit)

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.picasso)
     implementation(libs.joda.time)
-    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.jsoup)
 
     implementation(libs.bundles.media3)


### PR DESCRIPTION
- Fix for Dokka error when running the docs build, see https://github.com/Kotlin/dokka/issues/2954#issuecomment-1694714170.
- Apply the Dokka plugin to all subprojects excepts for test-app
- Remove the old clean gradle task, it does the same thing as normal clean so it's pointless.
- Update several more libraries
- Restructure dependencies and bundles in the versions and gradle files. Note that coroutines-core was never needed, coroutines-android alone sufficed.