### PR TITLE
Remove `android:clearTaskOnLaunch`

### DIFF
--- a/test-app/src/main/AndroidManifest.xml
+++ b/test-app/src/main/AndroidManifest.xml
@@ -31,7 +31,6 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="n">
         <activity android:name=".MainActivity"
-            android:clearTaskOnLaunch="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This `AndroidManifest.xml` flag was added [to address an issue with the HTTP server](https://github.com/readium/r2-testapp-kotlin/pull/298). As [we remove the HTTP server](https://github.com/readium/kotlin-toolkit/pull/259), it's not needed anymore. Let's remove it as it [causes some issues](https://github.com/readium/kotlin-toolkit/issues/440).
 
* Fix #440 