### PR TITLE
Add LcpService.injectLicenseDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Added
 
-* The new `HyperlinkNavigator.shouldFollowInternalLink(Link, LinkContext?)` allows you to handle footnotes according to your preference.
+#### Navigator
+
+* The new `HyperlinkNavigator.shouldfollowinternallink(Link, LinkContext?)` allows you to handle footnotes according to your preference.
     * By default, the navigator now moves to the footnote content instead of displaying a pop-up as it did in version 2.x.
+
+#### LCP
+
+* You can use `LcpService.injectLicenseDocument()` to insert an LCPL into a package, if you downloaded it manually instead of using `LcpService.acquirePublication()`.
 
 
 ## [3.0.0-alpha.1]

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -120,10 +120,9 @@ public interface LcpService {
     ): Try<LcpLicense, LcpError>
 
     /**
-     * Injects license document into publication archive.
+     * Injects a [licenseDocument] into the given [publicationFile] package.
      *
-     * This is useful if you've downloaded the publication by your own means but not if you used
-     * [acquirePublication].
+     * This is useful if you downloaded the publication yourself instead of using [acquirePublication].
      */
     public suspend fun injectLicenseDocument(
         licenseDocument: LicenseDocument,

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -29,6 +29,7 @@ import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.asset.Asset
 import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.format.Format
+import org.readium.r2.shared.util.mediatype.MediaType
 
 /**
  * Service used to acquire and open publications protected with LCP.
@@ -49,6 +50,8 @@ public interface LcpService {
     /**
      * Acquires a protected publication from a standalone LCPL's bytes.
      *
+     * License will be injected into the publication archive without explicitly calling
+     * [injectLicenseDocument].
      * You can cancel the on-going acquisition by cancelling its parent coroutine context.
      *
      * @param onProgress Callback to follow the acquisition progress from 0.0 to 1.0.
@@ -61,6 +64,8 @@ public interface LcpService {
     /**
      * Acquires a protected publication from a standalone LCPL file.
      *
+     * License will be injected into the publication archive without explicitly calling
+     * [injectLicenseDocument].
      * You can cancel the on-going acquisition by cancelling its parent coroutine context.
      *
      * @param onProgress Callback to follow the acquisition progress from 0.0 to 1.0.
@@ -113,6 +118,18 @@ public interface LcpService {
         authentication: LcpAuthenticating,
         allowUserInteraction: Boolean
     ): Try<LcpLicense, LcpError>
+
+    /**
+     * Injects license document into publication archive.
+     *
+     * This is useful if you've downloaded the publication by your own means but not if you used
+     * [acquirePublication].
+     */
+    public suspend fun injectLicenseDocument(
+        licenseDocument: LicenseDocument,
+        publicationFile: File,
+        mediaType: MediaType? = null
+    ): Try<Unit, LcpError>
 
     /**
      * Creates a [ContentProtection] instance which can be used with a Streamer to unlock


### PR DESCRIPTION
`LcpService.injectLicenseDocument` enables apps to download publications with a custom engine (possibly working in background) and then manually inject the license document into the publication file.