### PR TITLE
Fix EPUB deobfuscation

### DIFF
--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubDeobfuscator.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubDeobfuscator.kt
@@ -27,9 +27,7 @@ internal class EpubDeobfuscator(
     @Suppress("Unused_parameter")
     fun transform(url: Url, resource: Resource): Resource =
         resource.flatMap {
-            val algorithm = resource.sourceUrl
-                ?.let { encryptionData[it] }
-                ?.algorithm
+            val algorithm = encryptionData[url]?.algorithm
             if (algorithm != null && algorithm2length.containsKey(algorithm)) {
                 DeobfuscatingResource(resource, algorithm)
             } else {
@@ -71,9 +69,10 @@ internal class EpubDeobfuscator(
     )
 
     private fun deobfuscate(bytes: ByteArray, obfuscationKey: ByteArray, obfuscationLength: Int) {
-        val toDeobfuscate = 0 until obfuscationLength
-        for (i in toDeobfuscate)
+        val toDeobfuscate = 0 until obfuscationLength.coerceAtMost(bytes.size)
+        for (i in toDeobfuscate) {
             bytes[i] = bytes[i].xor(obfuscationKey[i % obfuscationKey.size])
+        }
     }
 
     private fun getHashKeyAdobe(pubId: String) =


### PR DESCRIPTION
EPUB deobfuscation is broken since 3.0.0-alpha.1, as we were using `sourceUrl` instead of `Url` in the resource transformer. As `sourceUrl` refers to an absolute URL, it was always `null` for the resources of an EPUB package.

This PR also prevents crashes when deobfuscating a resource that is smaller than the expected obfuscation length.