### PR TITLE
Simplify LcpService.injectLicense

### DIFF
--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -29,7 +29,6 @@ import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.asset.Asset
 import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.format.Format
-import org.readium.r2.shared.util.mediatype.MediaType
 
 /**
  * Service used to acquire and open publications protected with LCP.
@@ -126,8 +125,7 @@ public interface LcpService {
      */
     public suspend fun injectLicenseDocument(
         licenseDocument: LicenseDocument,
-        publicationFile: File,
-        mediaType: MediaType? = null
+        publicationFile: File
     ): Try<Unit, LcpError>
 
     /**

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -68,9 +68,9 @@ internal class LicensesService(
 
     override suspend fun injectLicenseDocument(
         licenseDocument: LicenseDocument,
-        publicationFile: File,
-        mediaType: MediaType?
+        publicationFile: File
     ): Try<Unit, LcpError> {
+        val mediaType = licenseDocument.publicationLink.mediaType
         val format = assetRetriever.sniffFormat(publicationFile, FormatHints(mediaType))
             .getOrElse {
                 Format(


### PR DESCRIPTION
MediaType is known from the license document.