### PR TITLE
Prevent reporting the current position while loading a locator

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -55,8 +55,12 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
 
     interface Listener {
         val readingProgression: ReadingProgression
-        fun onResourceLoaded(link: Link?, webView: R2BasicWebView, url: String?) {}
-        fun onPageLoaded() {}
+
+        /** Called when the resource content is loaded in the web view. */
+        fun onResourceLoaded(webView: R2BasicWebView, link: Link) {}
+
+        /** Called when the target page of the resource is loaded in the web view. */
+        fun onPageLoaded(webView: R2BasicWebView, link: Link) {}
         fun onPageChanged(pageIndex: Int, totalPages: Int, url: String) {}
         fun onPageEnded(end: Boolean) {}
         fun onTap(point: PointF): Boolean = false

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -781,7 +781,7 @@ public class EpubNavigatorFragment internal constructor(
         override fun onPageLoaded(webView: R2BasicWebView, link: Link) {
             paginationListener?.onPageLoaded()
 
-            if ((state as? State.Loading)?.locator?.href == link.url()) {
+            if (state is State.Initializing || (state as? State.Loading)?.locator?.href == link.url()) {
                 state = State.Ready
             }
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -140,20 +140,18 @@ internal class EpubNavigatorViewModel(
             .launchIn(viewModelScope)
     }
 
-    fun onResourceLoaded(link: Link?, webView: R2BasicWebView): RunScriptCommand {
+    fun onResourceLoaded(webView: R2BasicWebView, link: Link): RunScriptCommand {
         val templates = decorationTemplates.toJSON().toString()
             .replace("\\n", " ")
         var script = "readium.registerDecorationTemplates($templates);\n"
 
-        if (link != null) {
-            for ((group, decorations) in decorations) {
-                val changes = decorations
-                    .filter { it.locator.href == link.url() }
-                    .map { DecorationChange.Added(it) }
+        for ((group, decorations) in decorations) {
+            val changes = decorations
+                .filter { it.locator.href == link.url() }
+                .map { DecorationChange.Added(it) }
 
-                val groupScript = changes.javascriptForGroup(group, decorationTemplates) ?: continue
-                script += "$groupScript\n"
-            }
+            val groupScript = changes.javascriptForGroup(group, decorationTemplates) ?: continue
+            script += "$groupScript\n"
         }
 
         return RunScriptCommand(script, scope = RunScriptCommand.Scope.WebView(webView))

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -217,7 +217,9 @@ internal class R2EpubPageFragment : Fragment() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
 
-                webView.listener?.onResourceLoaded(link, webView, url)
+                link?.let {
+                    webView.listener?.onResourceLoaded(webView, it)
+                }
 
                 // To make sure the page is properly laid out before jumping to the target locator,
                 // we execute a dummy JavaScript and wait for the callback result.
@@ -370,7 +372,9 @@ internal class R2EpubPageFragment : Fragment() {
                     }
                     .also { pendingLocator = null }
 
-                webView.listener?.onPageLoaded()
+                link?.let {
+                    webView.listener?.onPageLoaded(webView, it)
+                }
             }
         }
     }

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2PagerAdapter.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2PagerAdapter.kt
@@ -16,6 +16,7 @@ import androidx.collection.LongSparseArray
 import androidx.collection.forEach
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import org.readium.r2.navigator.extensions.let
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.AbsoluteUrl
@@ -83,7 +84,10 @@ internal class R2PagerAdapter internal constructor(
                 )
             }
             is PageResource.EpubFxl -> {
-                R2FXLPageFragment.newInstance(resource.leftUrl, resource.rightUrl)
+                R2FXLPageFragment.newInstance(
+                    left = let(resource.leftLink, resource.leftUrl) { l, u -> Pair(l, u) },
+                    right = let(resource.rightLink, resource.rightUrl) { l, u -> Pair(l, u) }
+                )
             }
             is PageResource.Cbz -> {
                 fm.fragmentFactory

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -15,7 +15,6 @@ import kotlin.reflect.KClass
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import org.readium.r2.shared.*
-import org.readium.r2.shared.extensions.*
 import org.readium.r2.shared.publication.epub.listOfAudioClips
 import org.readium.r2.shared.publication.epub.listOfVideoClips
 import org.readium.r2.shared.publication.services.CacheService

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/format/Sniffers.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/format/Sniffers.kt
@@ -25,7 +25,6 @@ import org.readium.r2.shared.util.data.decodeRwpm
 import org.readium.r2.shared.util.data.decodeString
 import org.readium.r2.shared.util.data.decodeXml
 import org.readium.r2.shared.util.data.readDecodeOrElse
-import org.readium.r2.shared.util.getOrDefault
 import org.readium.r2.shared.util.getOrElse
 import org.readium.r2.shared.util.mediatype.MediaType
 
@@ -1245,7 +1244,11 @@ public object JavaScriptSniffer : FormatSniffer {
 }
 
 private suspend fun Readable.canReadWholeBlob() =
-    length().getOrDefault(0) < 5 * 1000 * 1000
+    length()
+        .fold(
+            onSuccess = { it < 5 * 1000 * 1000 },
+            onFailure = { false }
+        )
 
 /**
  * Returns whether the content is a JSON object containing all of the given root keys.


### PR DESCRIPTION
While loading the EPUB navigator's initial locator, calling certain APIs too early, like `submitPreferences()`, can cause us to lose it. This happens because the `currentLocator` goes through various temporary positions before settling on the requested initial locator. If we invalidate the view pager while loading, the pending locator is cleared and replaced with the current state of the `currentLocator`.

I solved this by adding a `State` in the `EpubNavigatorFragment` to monitor the loading of pending locators. `currentLocator` will only update after the requested locator finishes loading.