### PR TITLE
Downgrade to jsoup 1.16.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,11 @@ google-exoplayer = "2.19.1"
 google-material = "1.11.0"
 
 joda-time = "2.12.6"
-jsoup = "1.17.2"
+# Jsoup 1.16.2 requires core library desugaring, otherwise it crashes on Android 7 devices when
+# opening the EPUB navigator.
+# Before enabling desugaring, we need to assess its impact on the toolkit.
+# See https://github.com/jhy/jsoup/issues/2022#issuecomment-1783931119
+jsoup = "1.16.1"
 junit = "4.13.2"
 
 kotlinx-coroutines = "1.7.3"

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIteratorTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIteratorTest.kt
@@ -54,7 +54,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.0,
-                selector = "html > body > section > div.center",
+                selector = "#pgepubid00498 > div.center",
                 before = null,
                 highlight = "171"
             ),
@@ -63,7 +63,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.0,
-                        selector = "html > body > section > div.center",
+                        selector = "#pgepubid00498 > div.center",
                         before = null,
                         highlight = "171"
                     ),
@@ -75,7 +75,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.2,
-                selector = "html > body > section > h3",
+                selector = "#pgepubid00498 > h3",
                 before = "171",
                 highlight = "INTRODUCTORY"
             ),
@@ -84,7 +84,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.2,
-                        selector = "html > body > section > h3",
+                        selector = "#pgepubid00498 > h3",
                         before = "171",
                         highlight = "INTRODUCTORY"
                     ),
@@ -96,7 +96,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.4,
-                selector = "html > body > section > p:nth-child(3)",
+                selector = "#pgepubid00498 > p:nth-child(3)",
                 before = "171INTRODUCTORY",
                 highlight = "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales."
             ),
@@ -105,7 +105,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.4,
-                        selector = "html > body > section > p:nth-child(3)",
+                        selector = "#pgepubid00498 > p:nth-child(3)",
                         before = "171INTRODUCTORY",
                         highlight = "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales."
                     ),
@@ -117,7 +117,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.6,
-                selector = "html > body > section > p:nth-child(4)",
+                selector = "#pgepubid00498 > p:nth-child(4)",
                 before = "ade off into the more modern types of short tales.",
                 highlight = "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization."
             ),
@@ -126,7 +126,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.6,
-                        selector = "html > body > section > p:nth-child(4)",
+                        selector = "#pgepubid00498 > p:nth-child(4)",
                         before = "ade off into the more modern types of short tales.",
                         highlight = "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization."
                     ),
@@ -138,7 +138,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.8,
-                selector = "html > body > section > p:nth-child(5)",
+                selector = "#pgepubid00498 > p:nth-child(5)",
                 before = "secrets as the price of an advancing civilization.",
                 highlight = "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature."
             ),
@@ -147,7 +147,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.8,
-                        selector = "html > body > section > p:nth-child(5)",
+                        selector = "#pgepubid00498 > p:nth-child(5)",
                         before = "secrets as the price of an advancing civilization.",
                         highlight = "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature."
                     ),
@@ -271,13 +271,13 @@ class HtmlResourceContentIteratorTest {
 
     @Test
     fun `starting from a CSS selector`() = runTest {
-        val iter = iterator(html, locator(selector = "html > body > section > p:nth-child(3)"))
+        val iter = iterator(html, locator(selector = "#pgepubid00498 > p:nth-child(3)"))
         assertEquals(elements.subList(2, elements.size), iter.elements())
     }
 
     @Test
     fun `calling previous() when starting from a CSS selector`() = runTest {
-        val iter = iterator(html, locator(selector = "html > body > section > p:nth-child(3)"))
+        val iter = iterator(html, locator(selector = "#pgepubid00498 > p:nth-child(3)"))
         assertTrue(iter.hasPrevious())
         assertEquals(elements[1], iter.previous())
     }
@@ -557,7 +557,7 @@ class HtmlResourceContentIteratorTest {
                 TextElement(
                     locator = locator(
                         progression = 2 / 3.0,
-                        selector = "html > body > ol.decimal > li > aside",
+                        selector = "#c06-li-0001 > aside",
                         before = "e just described is very much a waterfall process.\n                        \n                        ",
                         highlight = "Trailing text"
                     ),
@@ -566,7 +566,7 @@ class HtmlResourceContentIteratorTest {
                         Segment(
                             locator = locator(
                                 progression = 2 / 3.0,
-                                selector = "html > body > ol.decimal > li > aside",
+                                selector = "#c06-li-0001 > aside",
                                 before = "e just described is very much a waterfall process.\n                        ",
                                 highlight = "Trailing text"
                             ),


### PR DESCRIPTION
Jsoup 1.16.2 requires core library desugaring, otherwise it crashes on Android 7 devices when opening the EPUB navigator.

See https://github.com/jhy/jsoup/issues/2022#issuecomment-1783931119

Before enabling desugaring, we need to assess its impact on the toolkit. Until we do, I downgraded this dependency.
