### PR TITLE
Fix opening LCP-protected publication in restricted mode

### DIFF
--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
@@ -82,8 +82,12 @@ internal class LcpContentProtection(
         asset: ContainerAsset,
         license: Try<LcpLicense, LcpError>
     ): Try<ContentProtection.OpenResult, ContentProtection.OpenError> {
+        // ContentProtectionService should not expose errors due to user cancellation
+        val error = license.failureOrNull()
+            .takeUnless { it is LcpError.MissingCredentials }
+
         val serviceFactory = LcpContentProtectionService
-            .createFactory(license.getOrNull(), license.failureOrNull())
+            .createFactory(license.getOrNull(), error)
 
         val encryptionData =
             when {

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
@@ -84,7 +84,7 @@ internal class LcpContentProtection(
     ): Try<ContentProtection.OpenResult, ContentProtection.OpenError> {
         // ContentProtectionService should not expose errors due to user cancellation
         val error = license.failureOrNull()
-            .takeUnless { it is LcpError.MissingCredentials }
+            .takeUnless { it is LcpError.MissingPassphrase }
 
         val serviceFactory = LcpContentProtectionService
             .createFactory(license.getOrNull(), error)

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpError.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpError.kt
@@ -21,6 +21,9 @@ public sealed class LcpError(
     override val cause: Error? = null
 ) : Error {
 
+    public object MissingCredentials :
+        LcpError("Credentials are not available.")
+
     /** The interaction is not available with this License. */
     public object LicenseInteractionNotAvailable :
         LcpError("This interaction is not available.")

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpError.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpError.kt
@@ -21,8 +21,8 @@ public sealed class LcpError(
     override val cause: Error? = null
 ) : Error {
 
-    public object MissingCredentials :
-        LcpError("Credentials are not available.")
+    public object MissingPassphrase :
+        LcpError("Passphrase is not available.")
 
     /** The interaction is not available with this License. */
     public object LicenseInteractionNotAvailable :

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
@@ -234,7 +234,7 @@ internal class LicenseValidation(
                 transitionTo(State.failure(it.error))
             }
             on<Event.cancelled> {
-                if (DEBUG) Timber.d("State.cancelled)")
+                if (DEBUG) Timber.d("State.cancelled")
                 transitionTo(State.cancelled)
             }
         }

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -340,7 +340,7 @@ internal class LicensesService(
 
             // Both error and documents can be null if the user cancelled the passphrase prompt.
             if (documents == null) {
-                throw LcpException(LcpError.MissingCredentials)
+                throw LcpException(LcpError.MissingPassphrase)
             }
         }
     }

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -127,6 +127,8 @@ internal class LicensesService(
             val licenseDocument = LicenseDocument(lcpl)
             Timber.d("license ${licenseDocument.json}")
             fetchPublication(licenseDocument, destination, onProgress).let { Try.success(it) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             tryOrLog { destination.delete() }
             Try.failure(LcpError.wrap(e))
@@ -338,7 +340,7 @@ internal class LicensesService(
 
             // Both error and documents can be null if the user cancelled the passphrase prompt.
             if (documents == null) {
-                throw CancellationException("License validation was interrupted.")
+                throw LcpException(LcpError.MissingCredentials)
             }
         }
     }

--- a/test-app/src/main/java/org/readium/r2/testapp/domain/LcpUserError.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/domain/LcpUserError.kt
@@ -20,7 +20,7 @@ fun LcpError.toUserError(): UserError = when (this) {
     is LcpError.Network ->
         UserError(R.string.lcp_error_network, cause = this)
 
-    is LcpError.Runtime ->
+    is LcpError.Runtime, LcpError.MissingPassphrase ->
         UserError(R.string.lcp_error_runtime, cause = this)
     is LcpError.Unknown ->
         UserError(R.string.lcp_error_unknown, cause = this)


### PR DESCRIPTION
Return LcpError.MissingCredentials instead of throwing CancellationException if user cancels authentication