### PR TITLE
Enable core library desugaring

### DIFF
--- a/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
@@ -23,6 +23,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -53,6 +54,10 @@ android {
 
 kotlin {
     explicitApi()
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }
 
 mavenPublishing {

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,6 +2,13 @@
 
 All migration steps necessary in reading apps to upgrade to major versions of the Kotlin Readium toolkit will be documented in this file.
 
+## Unreleased
+
+### Core library desugaring
+
+If you target Android devices running below API 26, you now must enable [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) in your application module.
+
+
 ## 3.0.0-alpha.2
 
 ### Deprecation of `DownloadManager`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 
 kotlin = "1.9.22"
 agp = "8.2.2"
+desugar_jdk_libs = "2.0.4"
 gradle-maven-publish-plugin = "0.27.0"
 
 accompanist = "0.34.0"
@@ -123,6 +124,7 @@ androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "a
 
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 
+desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 google-exoplayer-core = { group = "com.google.android.exoplayer", name = "exoplayer-core", version.ref = "google-exoplayer" }
 google-exoplayer-extension-media2 = { group = "com.google.android.exoplayer", name = "extension-media2", version.ref = "google-exoplayer" }
 google-exoplayer-mediasession = { group = "com.google.android.exoplayer", name = "extension-mediasession", version.ref = "google-exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,11 +47,7 @@ google-exoplayer = "2.19.1"
 google-material = "1.11.0"
 
 joda-time = "2.12.6"
-# Jsoup 1.16.2 requires core library desugaring, otherwise it crashes on Android 7 devices when
-# opening the EPUB navigator.
-# Before enabling desugaring, we need to assess its impact on the toolkit.
-# See https://github.com/jhy/jsoup/issues/2022#issuecomment-1783931119
-jsoup = "1.16.1"
+jsoup = "1.17.2"
 junit = "4.13.2"
 
 kotlinx-coroutines = "1.7.3"

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIteratorTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/services/content/iterators/HtmlResourceContentIteratorTest.kt
@@ -54,7 +54,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.0,
-                selector = "#pgepubid00498 > div.center",
+                selector = "html > body > section > div.center",
                 before = null,
                 highlight = "171"
             ),
@@ -63,7 +63,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.0,
-                        selector = "#pgepubid00498 > div.center",
+                        selector = "html > body > section > div.center",
                         before = null,
                         highlight = "171"
                     ),
@@ -75,7 +75,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.2,
-                selector = "#pgepubid00498 > h3",
+                selector = "html > body > section > h3",
                 before = "171",
                 highlight = "INTRODUCTORY"
             ),
@@ -84,7 +84,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.2,
-                        selector = "#pgepubid00498 > h3",
+                        selector = "html > body > section > h3",
                         before = "171",
                         highlight = "INTRODUCTORY"
                     ),
@@ -96,7 +96,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.4,
-                selector = "#pgepubid00498 > p:nth-child(3)",
+                selector = "html > body > section > p:nth-child(3)",
                 before = "171INTRODUCTORY",
                 highlight = "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales."
             ),
@@ -105,7 +105,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.4,
-                        selector = "#pgepubid00498 > p:nth-child(3)",
+                        selector = "html > body > section > p:nth-child(3)",
                         before = "171INTRODUCTORY",
                         highlight = "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales."
                     ),
@@ -117,7 +117,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.6,
-                selector = "#pgepubid00498 > p:nth-child(4)",
+                selector = "html > body > section > p:nth-child(4)",
                 before = "ade off into the more modern types of short tales.",
                 highlight = "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization."
             ),
@@ -126,7 +126,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.6,
-                        selector = "#pgepubid00498 > p:nth-child(4)",
+                        selector = "html > body > section > p:nth-child(4)",
                         before = "ade off into the more modern types of short tales.",
                         highlight = "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization."
                     ),
@@ -138,7 +138,7 @@ class HtmlResourceContentIteratorTest {
         TextElement(
             locator = locator(
                 progression = 0.8,
-                selector = "#pgepubid00498 > p:nth-child(5)",
+                selector = "html > body > section > p:nth-child(5)",
                 before = "secrets as the price of an advancing civilization.",
                 highlight = "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature."
             ),
@@ -147,7 +147,7 @@ class HtmlResourceContentIteratorTest {
                 Segment(
                     locator = locator(
                         progression = 0.8,
-                        selector = "#pgepubid00498 > p:nth-child(5)",
+                        selector = "html > body > section > p:nth-child(5)",
                         before = "secrets as the price of an advancing civilization.",
                         highlight = "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature."
                     ),
@@ -271,13 +271,13 @@ class HtmlResourceContentIteratorTest {
 
     @Test
     fun `starting from a CSS selector`() = runTest {
-        val iter = iterator(html, locator(selector = "#pgepubid00498 > p:nth-child(3)"))
+        val iter = iterator(html, locator(selector = "html > body > section > p:nth-child(3)"))
         assertEquals(elements.subList(2, elements.size), iter.elements())
     }
 
     @Test
     fun `calling previous() when starting from a CSS selector`() = runTest {
-        val iter = iterator(html, locator(selector = "#pgepubid00498 > p:nth-child(3)"))
+        val iter = iterator(html, locator(selector = "html > body > section > p:nth-child(3)"))
         assertTrue(iter.hasPrevious())
         assertEquals(elements[1], iter.previous())
     }
@@ -557,7 +557,7 @@ class HtmlResourceContentIteratorTest {
                 TextElement(
                     locator = locator(
                         progression = 2 / 3.0,
-                        selector = "#c06-li-0001 > aside",
+                        selector = "html > body > ol.decimal > li > aside",
                         before = "e just described is very much a waterfall process.\n                        \n                        ",
                         highlight = "Trailing text"
                     ),
@@ -566,7 +566,7 @@ class HtmlResourceContentIteratorTest {
                         Segment(
                             locator = locator(
                                 progression = 2 / 3.0,
-                                selector = "#c06-li-0001 > aside",
+                                selector = "html > body > ol.decimal > li > aside",
                                 before = "e just described is very much a waterfall process.\n                        ",
                                 highlight = "Trailing text"
                             ),

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -31,6 +31,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
@@ -65,6 +66,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.legacy.v4)
 


### PR DESCRIPTION
If you target Android devices running below API 26, you now must enable [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) in your application module.

This is required by some of our third-party dependencies, such as `kotlinx-datetime` or `jsoup`.