### PR TITLE
Fix broken EPUB selection in paginated mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 * All the `completion` parameters of the `Navigator` APIs are removed.
 
+### Fixed
+
+#### Navigator
+
+* [#325](https://github.com/readium/kotlin-toolkit/issues/325) Top EPUB selections no longer break when dragging the selection handles.
+
 
 ## [3.0.0-alpha.2]
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -186,6 +186,13 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
     }
 
     override fun onOverScrolled(scrollX: Int, scrollY: Int, clampedX: Boolean, clampedY: Boolean) {
+        // Workaround addressing a bug in the Android WebView where the viewport is scrolled while
+        // dragging the text selection handles.
+        // See https://github.com/readium/kotlin-toolkit/issues/325
+        if (isSelecting) {
+            return
+        }
+
         if (callback != null) {
             callback?.onOverScrolled(scrollX, scrollY, clampedX, clampedY)
         }


### PR DESCRIPTION
### Fixed

#### Navigator

* [#325](https://github.com/readium/kotlin-toolkit/issues/325) Top EPUB selections no longer break when dragging the selection handles.

---

Technically the bug is still there (as it requires a fix in the Android WebView), but as the viewport is not scrolling, we can recover gracefully by continuing dragging.

https://github.com/readium/kotlin-toolkit/assets/58686775/a153c43c-abbb-45f6-8eca-68c09ea9db8e


