### PR TITLE
Fix handling EPUB `noteref` with nested elements

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -287,7 +287,7 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
         // We ignore taps on interactive element, unless it's an element we handle ourselves such as
         // pop-up footnotes.
         if (event.interactiveElement != null) {
-            return handleFootnote(event.targetElement)
+            return handleFootnote(event.interactiveElement)
         }
 
         return runBlocking(uiScope.coroutineContext) { listener?.onTap(event.point) ?: false }


### PR DESCRIPTION
EPUB `noteref` links containing nested HTML elements were not always reported as footnotes, as we were checking the `epub:type="noteref"` attribute on the `targetElement`, which might not be the `<a>`.

For example with `<a epub:type="noteref" href="notas.xhtml#nt1" id="rf1"><sup>1</sup></a>.</p>`,

`interactiveElement` is the whole `<a>`, while `targetElement` might be `<sup>1</sup>`, depending where we clicked.