### PR TITLE
Fix applying preferences while recreating EPUB fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * [#325](https://github.com/readium/kotlin-toolkit/issues/325) Top EPUB selections no longer break when dragging the selection handles.
+* Fixed applying preferences while the EPUB navigator fragment is being recreated.
 
 
 ## [3.0.0-alpha.2]

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -294,8 +294,7 @@ public class EpubNavigatorFragment internal constructor(
     public suspend fun evaluateJavascript(script: String): String? {
         val page = currentReflowablePageFragment ?: return null
         page.awaitLoaded()
-        val webView = page.webView ?: return null
-        return webView.runJavaScriptSuspend(script)
+        return page.runJavaScriptSuspend(script)
     }
 
     private val viewModel: EpubNavigatorViewModel by viewModels {
@@ -665,17 +664,17 @@ public class EpubNavigatorFragment internal constructor(
     private fun run(command: RunScriptCommand) {
         when (command.scope) {
             RunScriptCommand.Scope.CurrentResource -> {
-                currentReflowablePageFragment?.webView
+                currentReflowablePageFragment
                     ?.runJavaScript(command.script)
             }
             RunScriptCommand.Scope.LoadedResources -> {
                 r2PagerAdapter?.mFragments?.forEach { _, fragment ->
-                    (fragment as? R2EpubPageFragment)?.webView
+                    (fragment as? R2EpubPageFragment)
                         ?.runJavaScript(command.script)
                 }
             }
             is RunScriptCommand.Scope.Resource -> {
-                loadedFragmentForHref(command.scope.href)?.webView
+                loadedFragmentForHref(command.scope.href)
                     ?.runJavaScript(command.script)
             }
             is RunScriptCommand.Scope.WebView -> {
@@ -713,9 +712,9 @@ public class EpubNavigatorFragment internal constructor(
     // SelectableNavigator
 
     override suspend fun currentSelection(): Selection? {
-        val webView = currentReflowablePageFragment?.webView ?: return null
+        val fragment = currentReflowablePageFragment ?: return null
         val json =
-            webView.runJavaScriptSuspend("readium.getCurrentSelection();")
+            fragment.runJavaScriptSuspend("readium.getCurrentSelection();")
                 .takeIf { it != "null" }
                 ?.let { tryOrLog { JSONObject(it) } }
                 ?: return null

--- a/readium/opds/src/main/java/org/readium/r2/opds/OPDS1Parser.kt
+++ b/readium/opds/src/main/java/org/readium/r2/opds/OPDS1Parser.kt
@@ -81,7 +81,7 @@ public class OPDS1Parser {
             ReplaceWith("parse(jsonData, url.toUrl()!!)"),
             DeprecationLevel.ERROR
         )
-        public fun parse(jsonData: ByteArray, url: URL): ParseData =
+        public fun parse(xmlData: ByteArray, url: URL): ParseData =
             throw NotImplementedError()
 
         private fun parseFeed(root: ElementNode, url: Url): Feed {


### PR DESCRIPTION
Sometimes we need to trigger JavaScript during a configuration change. For example if the user submit new preferences (use case: switching the EPUB `theme` when the system mode changes).

This fails because the JavaScript layer (`readium` namespace) is not yet loaded.

As a workaround, we schedule incoming JavaScript requests until the webview page is loaded again.