### PR TITLE
Change LCP device name strategy

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -4,3 +4,5 @@
 # GitHub Copilot persisted chat sessions
 /copilot/chatSessions
 appInsightsSettings.xml
+deploymentTargetSelector.xml
+studiobot.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * All the APIs using or returning a `Date` objects are now using a custom `Instant` type. 
 
+#### LCP
+
+* [#493](https://github.com/readium/kotlin-toolkit/discussions/493) The LCP module does not require the Bluetooth permissions anymore to derive the device name.
+
 ### Fixed
 
 #### Navigator

--- a/readium/lcp/src/main/AndroidManifest.xml
+++ b/readium/lcp/src/main/AndroidManifest.xml
@@ -4,10 +4,4 @@
   available in the top-level LICENSE file of the project.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <!-- Used to get the device's name for LSD "register" -->
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-
-</manifest>
+<manifest />

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -166,10 +166,15 @@ public interface LcpService {
 
         /**
          * LCP service factory.
+         *
+         * @param deviceName Device name used when registering a license to an LSD server.
+         * If not provided, the device name will be generated from the device's manufacturer and
+         * model.
          */
         public operator fun invoke(
             context: Context,
-            assetRetriever: AssetRetriever
+            assetRetriever: AssetRetriever,
+            deviceName: String? = null
         ): LcpService? {
             if (!LcpClient.isAvailable()) {
                 return null
@@ -181,6 +186,7 @@ public interface LcpService {
             val licenseRepository = LicensesRepository(db)
             val network = NetworkService()
             val device = DeviceService(
+                deviceName = deviceName,
                 repository = deviceRepository,
                 network = network,
                 context = context

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
@@ -9,21 +9,16 @@
 
 package org.readium.r2.lcp.service
 
-import android.Manifest
-import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
-import androidx.core.app.ActivityCompat
+import android.os.Build
 import java.io.Serializable
-import java.util.*
-import kotlin.time.ExperimentalTime
+import java.util.UUID
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.components.Link
-import timber.log.Timber
 
-@OptIn(ExperimentalTime::class)
 internal class DeviceService(
+    deviceName: String?,
     private val repository: DeviceRepository,
     private val network: NetworkService,
     val context: Context
@@ -40,27 +35,9 @@ internal class DeviceService(
             preferences.edit().putString("lcp_device_id", deviceId).apply()
             return deviceId
         }
-    val name: String
-        get() {
-            val bluetoothManager =
-                context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-            val bluetoothName =
-                try {
-                    if (ActivityCompat.checkSelfPermission(
-                            context,
-                            Manifest.permission.BLUETOOTH_CONNECT
-                        ) != PackageManager.PERMISSION_GRANTED
-                    ) {
-                        null
-                    } else {
-                        bluetoothManager.adapter.name
-                    }
-                } catch (e: Exception) {
-                    Timber.e(e)
-                    null
-                }
-            return bluetoothName ?: "Android"
-        }
+
+    val name: String =
+        deviceName ?: "${Build.MANUFACTURER} ${Build.MODEL}"
 
     val asQueryParameters: URLParameters
         get() = mapOf("id" to id, "name" to name)


### PR DESCRIPTION
### Changed

#### LCP

* [#493](https://github.com/readium/kotlin-toolkit/discussions/493) The LCP module does not require the Bluetooth permissions anymore to derive the device name.

---

* Closes #493 