### PR TITLE
Support for the new 2.x LCP Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
+### Added
+
+* [#509](https://github.com/readium/kotlin-toolkit/issues/509) Support for the new 2.x LCP Profiles.
+
 ### Deprecated
 
 #### Navigator

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
@@ -9,7 +9,6 @@
 
 package org.readium.r2.lcp.license
 
-import java.util.*
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.lcp.BuildConfig.DEBUG
@@ -36,7 +35,17 @@ internal sealed class Either<A, B> {
 
 private val supportedProfiles = listOf(
     "http://readium.org/lcp/basic-profile",
-    "http://readium.org/lcp/profile-1.0"
+    "http://readium.org/lcp/profile-1.0",
+    "http://readium.org/lcp/profile-2.0",
+    "http://readium.org/lcp/profile-2.1",
+    "http://readium.org/lcp/profile-2.2",
+    "http://readium.org/lcp/profile-2.3",
+    "http://readium.org/lcp/profile-2.4",
+    "http://readium.org/lcp/profile-2.5",
+    "http://readium.org/lcp/profile-2.6",
+    "http://readium.org/lcp/profile-2.7",
+    "http://readium.org/lcp/profile-2.8",
+    "http://readium.org/lcp/profile-2.9"
 )
 
 internal typealias Context = Either<LcpClient.Context, LcpError.LicenseStatus>


### PR DESCRIPTION
### Added

* [#509](https://github.com/readium/kotlin-toolkit/issues/509) Support for the new 2.x LCP Profiles.

---

* Closes #509 