### PR TITLE
Rename `archive` Link property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * All the APIs using or returning a `Date` objects are now using a custom `Instant` type. 
 
+#### Shared
+
+* The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.
+
 #### LCP
 
 * [#493](https://github.com/readium/kotlin-toolkit/discussions/493) The LCP module does not require the Bluetooth permissions anymore to derive the device name.

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/archive/ArchiveProperties.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/archive/ArchiveProperties.kt
@@ -48,7 +48,7 @@ public data class ArchiveProperties(
     }
 }
 
-private const val ARCHIVE_KEY = "archive"
+private const val ARCHIVE_KEY = "https://readium.org/webpub-manifest/properties#archive"
 
 public val Resource.Properties.archive: ArchiveProperties?
     get() = (this[ARCHIVE_KEY] as? Map<*, *>)

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/resource/PropertiesTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/resource/PropertiesTest.kt
@@ -24,7 +24,7 @@ class PropertiesTest {
             ArchiveProperties(entryLength = 8273, isEntryCompressed = true),
             Resource.Properties(
                 mapOf(
-                    "archive" to mapOf(
+                    "https://readium.org/webpub-manifest/properties#archive" to mapOf(
                         "entryLength" to 8273,
                         "isEntryCompressed" to true
                     )
@@ -38,7 +38,7 @@ class PropertiesTest {
         assertNull(
             Resource.Properties(
                 mapOf(
-                    "archive" to mapOf(
+                    "https://readium.org/webpub-manifest/properties#archive" to mapOf(
                         "foo" to "bar"
                     )
                 )
@@ -51,7 +51,7 @@ class PropertiesTest {
         assertNull(
             Resource.Properties(
                 mapOf(
-                    "archive" to mapOf(
+                    "https://readium.org/webpub-manifest/properties#archive" to mapOf(
                         "isEntryCompressed" to true
                     )
                 )
@@ -61,7 +61,7 @@ class PropertiesTest {
         assertNull(
             Resource.Properties(
                 mapOf(
-                    "archive" to mapOf(
+                    "https://readium.org/webpub-manifest/properties#archive" to mapOf(
                         "entryLength" to 8273
                     )
                 )


### PR DESCRIPTION
### Changed

#### Shared

* The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.