### PR TITLE
Disable EPUB pagination with vertical text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+#### Navigator
+
+* EPUB: The `scroll` preference is now forced to `true` when rendering vertical text (e.g. CJK vertical). [See this discussion for the rationale](https://github.com/readium/swift-toolkit/discussions/370).
+
 
 ## [3.0.0-beta.1]
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubPreferencesEditor.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubPreferencesEditor.kt
@@ -329,7 +329,7 @@ public class EpubPreferencesEditor internal constructor(
         PreferenceDelegate(
             getValue = { preferences.scroll },
             getEffectiveValue = { state.settings.scroll },
-            getIsEffective = { layout == EpubLayout.REFLOWABLE },
+            getIsEffective = { layout == EpubLayout.REFLOWABLE && !state.settings.verticalText },
             updateValue = { value -> updateValues { it.copy(scroll = value) } }
         )
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettingsResolver.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettingsResolver.kt
@@ -28,6 +28,14 @@ internal class EpubSettingsResolver(
 
         val theme = preferences.theme ?: Theme.LIGHT
 
+        var scroll = preferences.scroll ?: defaults.scroll ?: false
+
+        // / We disable pagination with vertical text, because CSS columns don't support it properly.
+        // / See https://github.com/readium/swift-toolkit/discussions/370
+        if (verticalText) {
+            scroll = true
+        }
+
         return EpubSettings(
             backgroundColor = preferences.backgroundColor,
             columnCount = preferences.columnCount ?: defaults.columnCount ?: ColumnCount.AUTO,
@@ -45,7 +53,7 @@ internal class EpubSettingsResolver(
             paragraphSpacing = preferences.paragraphSpacing ?: defaults.paragraphSpacing,
             publisherStyles = preferences.publisherStyles ?: defaults.publisherStyles ?: true,
             readingProgression = readingProgression,
-            scroll = preferences.scroll ?: defaults.scroll ?: false,
+            scroll = scroll,
             spread = preferences.spread ?: defaults.spread ?: Spread.NEVER,
             textAlign = preferences.textAlign ?: defaults.textAlign,
             textColor = preferences.textColor,


### PR DESCRIPTION
### Changed

#### Navigator

* EPUB: The `scroll` preference is now forced to `true` when rendering vertical text (e.g. CJK vertical). [See this discussion for the rationale](https://github.com/readium/swift-toolkit/discussions/370).