### PR TITLE
Fix sniffing media types when acquiring an LCP publication

### DIFF
--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -152,7 +152,7 @@ internal class LicensesService(
 
         Timber.i("LCP destination $destination")
 
-        val mediaType = network.download(
+        val serverMediaType = network.download(
             url,
             destination,
             mediaType = link.mediaType,
@@ -173,8 +173,7 @@ internal class LicensesService(
                 destination,
                 FormatHints(
                     mediaTypes = listOfNotNull(
-                        license.publicationLink.mediaType,
-                        mediaType
+                        license.publicationLink.mediaType ?: serverMediaType
                     )
                 )
             ).getOrElse {


### PR DESCRIPTION
Some HTTP servers send wrong media types when downloading an LCP protected publication. For example returning `application/epub+zip` when downloading an LCPDF.

This failed the media type sniffing as we used both the license and HTTP server media types as hints.

Instead, now we use the license media type, and only the HTTP server media type as a fallback when missing.