### PR TITLE
Add a retrieveLicenseDocument method to LcpService

### DIFF
--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -28,6 +28,7 @@ import org.readium.r2.shared.publication.protection.ContentProtection
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.asset.Asset
 import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.shared.util.asset.ContainerAsset
 import org.readium.r2.shared.util.format.Format
 
 /**
@@ -117,6 +118,13 @@ public interface LcpService {
         authentication: LcpAuthenticating,
         allowUserInteraction: Boolean
     ): Try<LcpLicense, LcpError>
+
+    /**
+     * Retrieves the license document from a LCP-protected publication asset.
+     */
+    public suspend fun retrieveLicenseDocument(
+        asset: ContainerAsset
+    ): Try<LicenseDocument, LcpError>
 
     /**
      * Injects a [licenseDocument] into the given [publicationFile] package.

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -42,6 +42,7 @@ import org.readium.r2.shared.util.FileExtension
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.asset.Asset
 import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.shared.util.asset.ContainerAsset
 import org.readium.r2.shared.util.format.Format
 import org.readium.r2.shared.util.format.FormatHints
 import org.readium.r2.shared.util.format.FormatSpecification
@@ -241,6 +242,21 @@ internal class LicensesService(
             Try.success(license)
         } catch (e: Exception) {
             Try.failure(LcpError.wrap(e))
+        }
+
+    override suspend fun retrieveLicenseDocument(
+        asset: ContainerAsset
+    ): Try<LicenseDocument, LcpError> =
+        withContext(Dispatchers.IO) {
+            try {
+                val licenseContainer = createLicenseContainer(context, asset)
+                val licenseData = licenseContainer.read()
+                Try.success(LicenseDocument(licenseData))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Try.failure(LcpError.wrap(e))
+            }
         }
 
     private suspend fun retrieveLicense(


### PR DESCRIPTION
This is useful to get LCP metadata without unlocking a publication.