### PR TITLE
Prevent crash in case of misuse of AudioEngine.asPlayer().release

### DIFF
--- a/readium/adapters/exoplayer/audio/src/main/java/org/readium/adapter/exoplayer/audio/ExoPlayerEngine.kt
+++ b/readium/adapters/exoplayer/audio/src/main/java/org/readium/adapter/exoplayer/audio/ExoPlayerEngine.kt
@@ -179,6 +179,14 @@ public class ExoPlayerEngine private constructor(
     private val _playback: MutableStateFlow<AudioEngine.Playback> =
         MutableStateFlow(exoPlayer.playback)
 
+    private val sessionPlayer = object :
+        ForwardingPlayer(exoPlayer) {
+
+        override fun release() {
+            // This object does not own the ExoAudiobookPlayer instance, do not close it.
+        }
+    }
+
     init {
         coroutineScope.launch {
             val positionRefreshDelay = (1.0 / configuration.positionRefreshRate.value).seconds
@@ -227,7 +235,7 @@ public class ExoPlayerEngine private constructor(
     }
 
     override fun asPlayer(): Player {
-        return exoPlayer
+        return sessionPlayer
     }
 
     override fun submitPreferences(preferences: ExoPlayerPreferences) {

--- a/readium/navigators/media/audio/src/main/java/org/readium/navigator/media/audio/AudioEngine.kt
+++ b/readium/navigators/media/audio/src/main/java/org/readium/navigator/media/audio/AudioEngine.kt
@@ -32,22 +32,22 @@ public interface AudioEngine<S : Configurable.Settings, P : Configurable.Prefere
         /**
          * The player is ready to play.
          */
-        public object Ready : State()
+        public data object Ready : State()
 
         /**
          * The end of the content has been reached.
          */
-        public object Ended : State()
+        public data object Ended : State()
 
         /**
          * The engine cannot play because the buffer is starved.
          */
-        public object Buffering : State()
+        public data object Buffering : State()
 
         /**
          * The engine cannot play because an error occurred.
          */
-        public data class Failure(val error: AudioEngine.Error) : State()
+        public data class Failure(val error: Error) : State()
     }
 
     /**

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsEngine.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsEngine.kt
@@ -9,7 +9,6 @@ package org.readium.navigator.media.tts
 import org.readium.r2.navigator.preferences.Configurable
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.util.Closeable
-import org.readium.r2.shared.util.Error
 import org.readium.r2.shared.util.Language
 
 /**

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsNavigator.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsNavigator.kt
@@ -78,9 +78,9 @@ public class TtsNavigator<S : TtsEngine.Settings, P : TtsEngine.Preferences<P>,
 
     public sealed class State {
 
-        public object Ready : MediaNavigator.State.Ready
+        public data object Ready : MediaNavigator.State.Ready
 
-        public object Ended : MediaNavigator.State.Ended
+        public data object Ended : MediaNavigator.State.Ended
 
         public data class Failure(val error: Error) : MediaNavigator.State.Failure
     }


### PR DESCRIPTION
Closing a Media 3 adapter is not supposed to close the underlying player because it's still being used by the `AudioEngine` which assumes that the player will never reach the IDLE state again after preparing.