### PR TITLE
Remove SuspendingCloseable

### DIFF
--- a/readium/adapters/pdfium/document/src/main/java/org/readium/adapter/pdfium/document/PdfiumDocument.kt
+++ b/readium/adapters/pdfium/document/src/main/java/org/readium/adapter/pdfium/document/PdfiumDocument.kt
@@ -72,7 +72,7 @@ public class PdfiumDocument(
         core.getTableOfContents(document).map { it.toOutlineNode() }
     }
 
-    override suspend fun close() {
+    override fun close() {
         tryOrLog {
             core.closeDocument(document)
         }

--- a/readium/adapters/pspdfkit/document/src/main/java/org/readium/adapter/pspdfkit/document/PsPdfKitDocument.kt
+++ b/readium/adapters/pspdfkit/document/src/main/java/org/readium/adapter/pspdfkit/document/PsPdfKitDocument.kt
@@ -115,7 +115,7 @@ public class PsPdfKitDocument(
         document.outline.toOutlineNodes()
     }
 
-    override suspend fun close() {}
+    override fun close() {}
 }
 
 private fun List<OutlineElement>.toOutlineNodes(): List<PdfDocument.OutlineNode> =

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -199,7 +199,7 @@ public class Publication(
     /**
      * Closes any opened resource associated with the [Publication], including services.
      */
-    override suspend fun close() {
+    override fun close() {
         container.close()
         services.close()
     }

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/PublicationServicesHolder.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/PublicationServicesHolder.kt
@@ -11,12 +11,12 @@ package org.readium.r2.shared.publication
 import kotlin.reflect.KClass
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.tryOrLog
-import org.readium.r2.shared.util.SuspendingCloseable
+import org.readium.r2.shared.util.Closeable
 
 /**
  * Holds [Publication.Service] instances for a [Publication].
  */
-public interface PublicationServicesHolder : SuspendingCloseable {
+public interface PublicationServicesHolder : Closeable {
     /**
      * Returns the first publication service that is an instance of [serviceType].
      */
@@ -37,7 +37,7 @@ internal class ListPublicationServicesHolder(
     override fun <T : Publication.Service> findServices(serviceType: KClass<T>): List<T> =
         services.filterIsInstance(serviceType.java)
 
-    override suspend fun close() {
+    override fun close() {
         for (service in services) {
             tryOrLog { service.close() }
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/services/search/SearchService.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/services/search/SearchService.kt
@@ -12,8 +12,8 @@ import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.LocatorCollection
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.ServiceFactory
+import org.readium.r2.shared.util.Closeable
 import org.readium.r2.shared.util.Error
-import org.readium.r2.shared.util.SuspendingCloseable
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.data.ReadError
 
@@ -134,7 +134,7 @@ public var Publication.ServicesBuilder.searchServiceFactory: ServiceFactory?
  * Iterates through search results.
  */
 @ExperimentalReadiumApi
-public interface SearchIterator : SuspendingCloseable {
+public interface SearchIterator : Closeable {
 
     /**
      * Number of matches for this search, if known.
@@ -157,7 +157,7 @@ public interface SearchIterator : SuspendingCloseable {
      * Closes any resources allocated for the search query, such as a cursor.
      * To be called when the user dismisses the search.
      */
-    override suspend fun close() {}
+    override fun close() {}
 
     /**
      * Performs the given operation on each result page of this [SearchIterator].

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Closeable.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Closeable.kt
@@ -18,22 +18,10 @@ public interface Closeable {
 }
 
 /**
- * A [SuspendingCloseable] is an object holding closeable resources, such as open files or streams.
- */
-public interface SuspendingCloseable {
-
-    /**
-     * Closes this object and releases any resources associated with it.
-     * If the object is already closed then invoking this method has no effect.
-     */
-    public suspend fun close()
-}
-
-/**
  * Executes the given block function on this resource and then closes it down correctly whether
  * an exception is thrown or not.
  */
-public suspend inline fun <T : SuspendingCloseable?, R> T.use(block: (T) -> R): R {
+public inline fun <T : Closeable?, R> T.use(block: (T) -> R): R {
     var exception: Throwable? = null
     try {
         return block(this)

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/asset/Asset.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/asset/Asset.kt
@@ -6,7 +6,7 @@
 
 package org.readium.r2.shared.util.asset
 
-import org.readium.r2.shared.util.SuspendingCloseable
+import org.readium.r2.shared.util.Closeable
 import org.readium.r2.shared.util.data.Container
 import org.readium.r2.shared.util.format.Format
 import org.readium.r2.shared.util.resource.Resource
@@ -14,7 +14,7 @@ import org.readium.r2.shared.util.resource.Resource
 /**
  * An asset which is either a single resource or a container that holds multiple resources.
  */
-public sealed class Asset : SuspendingCloseable {
+public sealed class Asset : Closeable {
 
     /**
      * Format of the asset.
@@ -33,7 +33,7 @@ public class ContainerAsset(
     public val container: Container<Resource>
 ) : Asset() {
 
-    override suspend fun close() {
+    override fun close() {
         container.close()
     }
 }
@@ -49,7 +49,7 @@ public class ResourceAsset(
     public val resource: Resource
 ) : Asset() {
 
-    override suspend fun close() {
+    override fun close() {
         resource.close()
     }
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/content/ContentResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/content/ContentResource.kt
@@ -47,7 +47,7 @@ public class ContentResource(
 
     override val sourceUrl: AbsoluteUrl? = uri.toUrl() as? AbsoluteUrl
 
-    override suspend fun close() {
+    override fun close() {
     }
 
     override suspend fun properties(): Try<Resource.Properties, ReadError> {

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/data/Caching.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/data/Caching.kt
@@ -58,7 +58,7 @@ internal class CachingReadable(
         }
     }
 
-    override suspend fun close() {}
+    override fun close() {}
 }
 
 internal class CachingContainer(
@@ -81,7 +81,7 @@ internal class CachingContainer(
         return blobContext
     }
 
-    override suspend fun close() {
+    override fun close() {
         cache.forEach { it.value.close() }
         cache.clear()
     }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/data/Container.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/data/Container.kt
@@ -6,9 +6,10 @@
 
 package org.readium.r2.shared.util.data
 
+import kotlin.io.use
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.util.AbsoluteUrl
-import org.readium.r2.shared.util.SuspendingCloseable
+import org.readium.r2.shared.util.Closeable
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.use
@@ -16,7 +17,7 @@ import org.readium.r2.shared.util.use
 /**
  * A container provides access to a list of [Readable] entries.
  */
-public interface Container<out E : Readable> : Iterable<Url>, SuspendingCloseable {
+public interface Container<out E : Readable> : Iterable<Url>, Closeable {
 
     /**
      * Direct source to this container, when available.
@@ -45,7 +46,7 @@ public class EmptyContainer<E : Readable> :
 
     override fun get(url: Url): E? = null
 
-    override suspend fun close() {}
+    override fun close() {}
 }
 
 /**
@@ -69,7 +70,7 @@ public class CompositeContainer<E : Readable>(
     override fun get(url: Url): E? =
         containers.firstNotNullOfOrNull { it[url] }
 
-    override suspend fun close() {
+    override fun close() {
         containers.forEach { it.close() }
     }
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/data/Reading.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/data/Reading.kt
@@ -8,10 +8,10 @@ package org.readium.r2.shared.util.data
 
 import java.io.IOException
 import org.readium.r2.shared.InternalReadiumApi
+import org.readium.r2.shared.util.Closeable
 import org.readium.r2.shared.util.DebugError
 import org.readium.r2.shared.util.Error
 import org.readium.r2.shared.util.ErrorException
-import org.readium.r2.shared.util.SuspendingCloseable
 import org.readium.r2.shared.util.ThrowableError
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.getOrElse
@@ -19,7 +19,7 @@ import org.readium.r2.shared.util.getOrElse
 /**
  * Acts as a proxy to an actual data source by handling read access.
  */
-public interface Readable : SuspendingCloseable {
+public interface Readable : Closeable {
 
     /**
      * Returns data length from metadata if available, or calculated from reading the bytes otherwise.
@@ -120,7 +120,7 @@ private class BorrowedReadable(
     private val readable: Readable
 ) : Readable by readable {
 
-    override suspend fun close() {
+    override fun close() {
         // Do nothing
     }
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/file/DirectoryContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/file/DirectoryContainer.kt
@@ -30,7 +30,7 @@ public class DirectoryContainer(
         ?.let { File(root, it) }
         ?.let { FileResource(it) }
 
-    override suspend fun close() {}
+    override fun close() {}
 
     public companion object {
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/file/FileResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/file/FileResource.kt
@@ -13,7 +13,10 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.RandomAccessFile
 import java.nio.channels.Channels
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.*
@@ -58,11 +61,14 @@ public class FileResource(
         return Try.success(properties)
     }
 
-    override suspend fun close() {
-        withContext(Dispatchers.IO) {
-            if (::randomAccessFile.isLazyInitialized) {
-                randomAccessFile.onSuccess {
-                    tryOrLog { it.close() }
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun close() {
+        if (::randomAccessFile.isLazyInitialized) {
+            GlobalScope.launch {
+                withContext(Dispatchers.IO) {
+                    randomAccessFile.onSuccess {
+                        tryOrLog { it.close() }
+                    }
                 }
             }
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpContainer.kt
@@ -39,5 +39,5 @@ public class HttpContainer(
         }
     }
 
-    override suspend fun close() {}
+    override fun close() {}
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/http/HttpResource.kt
@@ -61,7 +61,7 @@ public class HttpResource(
             }
         }
 
-    override suspend fun close() {}
+    override fun close() {}
 
     override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> = withContext(
         Dispatchers.IO

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/pdf/PdfDocument.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/pdf/PdfDocument.kt
@@ -21,7 +21,7 @@ import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.PublicationServicesHolder
 import org.readium.r2.shared.publication.ReadingProgression
 import org.readium.r2.shared.publication.services.cacheService
-import org.readium.r2.shared.util.SuspendingCloseable
+import org.readium.r2.shared.util.Closeable
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.cache.Cache
 import org.readium.r2.shared.util.cache.getOrTryPut
@@ -72,7 +72,7 @@ private class CachingPdfDocumentFactory<T : PdfDocument>(
 /**
  * Represents a PDF document.
  */
-public interface PdfDocument : SuspendingCloseable {
+public interface PdfDocument : Closeable {
 
     /**
      * Permanent identifier based on the contents of the file at the time it was originally

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/FallbackResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/FallbackResource.kt
@@ -29,7 +29,7 @@ public class FallbackResource(
     override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> =
         withResource { read(range) }
 
-    override suspend fun close() {
+    override fun close() {
         if (::_resource.isInitialized) {
             _resource.close()
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/InMemoryResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/InMemoryResource.kt
@@ -60,7 +60,7 @@ public class InMemoryResource(
         return _bytes.map { it.read(range) }
     }
 
-    override suspend fun close() {}
+    override fun close() {}
 
     override fun toString(): String =
         "${javaClass.simpleName}(${runBlocking { length() }} bytes)"

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/LazyResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/LazyResource.kt
@@ -37,7 +37,7 @@ public open class LazyResource(
     override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> =
         resource().read(range)
 
-    override suspend fun close() {
+    override fun close() {
         if (::_resource.isInitialized) {
             _resource.close()
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/Resource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/Resource.kt
@@ -62,7 +62,7 @@ public class FailureResource(
     override suspend fun properties(): Try<Resource.Properties, ReadError> = Try.failure(error)
     override suspend fun length(): Try<Long, ReadError> = Try.failure(error)
     override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> = Try.failure(error)
-    override suspend fun close() {}
+    override fun close() {}
 
     override fun toString(): String =
         "${javaClass.simpleName}($error)"
@@ -81,7 +81,7 @@ private class BorrowedResource(
     private val resource: Resource
 ) : Resource by resource {
 
-    override suspend fun close() {
+    override fun close() {
         // Do nothing
     }
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/SingleResourceContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/SingleResourceContainer.kt
@@ -25,7 +25,7 @@ public class SingleResourceContainer(
         return resource.borrow()
     }
 
-    override suspend fun close() {
+    override fun close() {
         resource.close()
     }
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/SynchronizedResource.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/SynchronizedResource.kt
@@ -34,8 +34,8 @@ public class SynchronizedResource(
     override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> =
         mutex.withLock { resource.read(range) }
 
-    override suspend fun close() {
-        mutex.withLock { resource.close() }
+    override fun close() {
+        resource.close()
     }
 
     override fun toString(): String =

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/resource/TransformingContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/resource/TransformingContainer.kt
@@ -43,7 +43,7 @@ public class TransformingContainer(
             }
     }
 
-    override suspend fun close() {
+    override fun close() {
         container.close()
     }
 }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/zip/FileZipContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/zip/FileZipContainer.kt
@@ -13,7 +13,10 @@ import java.io.IOException
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException
 import java.util.zip.ZipFile
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.readFully
@@ -124,9 +127,12 @@ internal class FileZipContainer(
 
         private var stream: CountingInputStream? = null
 
-        override suspend fun close() {
-            withContext(Dispatchers.IO) {
-                tryOrLog { stream?.close() }
+        @OptIn(DelicateCoroutinesApi::class)
+        override fun close() {
+            GlobalScope.launch {
+                withContext(Dispatchers.IO) {
+                    tryOrLog { stream?.close() }
+                }
             }
         }
     }
@@ -147,10 +153,13 @@ internal class FileZipContainer(
             }
             ?.let { Entry(url, it) }
 
-    override suspend fun close() {
-        tryOrLog {
-            withContext(Dispatchers.IO) {
-                archive.close()
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun close() {
+        GlobalScope.launch {
+            tryOrLog {
+                withContext(Dispatchers.IO) {
+                    archive.close()
+                }
             }
         }
     }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/zip/StreamingZipContainer.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/zip/StreamingZipContainer.kt
@@ -8,7 +8,10 @@
 
 package org.readium.r2.shared.util.zip
 
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.findInstance
@@ -130,10 +133,13 @@ internal class StreamingZipContainer(
 
         private var stream: CountingInputStream? = null
 
-        override suspend fun close() {
-            tryOrLog {
+        @OptIn(DelicateCoroutinesApi::class)
+        override fun close() {
+            GlobalScope.launch {
                 withContext(Dispatchers.IO) {
-                    stream?.close()
+                    tryOrLog {
+                        stream?.close()
+                    }
                 }
             }
         }
@@ -151,9 +157,12 @@ internal class StreamingZipContainer(
             ?.takeUnless { it.isDirectory }
             ?.let { Entry(url, it) }
 
-    override suspend fun close() {
-        withContext(Dispatchers.IO) {
-            tryOrLog { zipFile.close() }
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun close() {
+        GlobalScope.launch {
+            withContext(Dispatchers.IO) {
+                tryOrLog { zipFile.close() }
+            }
         }
     }
 }

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/format/TestContainer.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/format/TestContainer.kt
@@ -27,5 +27,5 @@ class TestContainer(
     override fun get(url: Url): Resource? =
         resources[url]?.let { StringResource(it) }
 
-    override suspend fun close() {}
+    override fun close() {}
 }

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/EpubPositionsServiceTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/EpubPositionsServiceTest.kt
@@ -512,11 +512,11 @@ class EpubPositionsServiceTest {
                     override suspend fun read(range: LongRange?): ReadTry<ByteArray> =
                         Try.success(ByteArray(0))
 
-                    override suspend fun close() {}
+                    override fun close() {}
                 }
             }
 
-            override suspend fun close() {}
+            override fun close() {}
         },
         presentation = Presentation(layout = layout),
         reflowableStrategy = reflowableStrategy


### PR DESCRIPTION
Remove `SuspendingCloseable` because it does not make much sense and is a bit dangerous: freeing resources is not something you want to be cancellable.