### PR TITLE
Improve `Url` equality

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
@@ -58,6 +58,12 @@ internal fun String.toJsonOrNull(): JSONObject? =
     }
 
 /**
+ * Percent-decodes a string.
+ */
+internal fun String.percentDecoded(): String =
+    Uri.decode(this)
+
+/**
  * Percent-encodes an URL path section.
  *
  * Equivalent to Swift's `string.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)`

--- a/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
@@ -58,12 +58,6 @@ internal fun String.toJsonOrNull(): JSONObject? =
     }
 
 /**
- * Percent-decodes a string.
- */
-internal fun String.percentDecoded(): String =
-    Uri.decode(this)
-
-/**
  * Percent-encodes an URL path section.
  *
  * Equivalent to Swift's `string.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)`

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
@@ -18,7 +18,6 @@ import kotlinx.parcelize.Parcelize
 import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.isPrintableAscii
-import org.readium.r2.shared.extensions.percentDecoded
 import org.readium.r2.shared.extensions.percentEncodedPath
 import org.readium.r2.shared.extensions.tryOrNull
 
@@ -269,7 +268,7 @@ public class AbsoluteUrl private constructor(override val uri: Uri) : Url() {
 
         return scheme == other.scheme &&
             uri.authority == other.uri.authority &&
-            path?.percentDecoded() == other.path?.percentDecoded() &&
+            path == other.path &&
             query == other.query &&
             fragment == other.fragment
     }
@@ -304,7 +303,7 @@ public class RelativeUrl private constructor(override val uri: Uri) : Url() {
 
         other as RelativeUrl
 
-        return path?.percentDecoded() == other.path?.percentDecoded() &&
+        return path == other.path &&
             query == other.query &&
             fragment == other.fragment
     }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
@@ -18,6 +18,7 @@ import kotlinx.parcelize.Parcelize
 import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.isPrintableAscii
+import org.readium.r2.shared.extensions.percentDecoded
 import org.readium.r2.shared.extensions.percentEncodedPath
 import org.readium.r2.shared.extensions.tryOrNull
 
@@ -176,17 +177,6 @@ public sealed class Url : Parcelable {
     override fun toString(): String =
         uri.toString()
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Url
-
-        if (uri.toString() != other.uri.toString()) return false
-
-        return true
-    }
-
     override fun hashCode(): Int =
         uri.toString().hashCode()
 
@@ -270,6 +260,19 @@ public class AbsoluteUrl private constructor(override val uri: Uri) : Url() {
      */
     public fun toFile(): File? =
         if (isFile) File(path!!) else null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AbsoluteUrl
+
+        return scheme == other.scheme &&
+            uri.authority == other.uri.authority &&
+            path?.percentDecoded() == other.path?.percentDecoded() &&
+            query == other.query &&
+            fragment == other.fragment
+    }
 }
 
 /**
@@ -293,6 +296,17 @@ public class RelativeUrl private constructor(override val uri: Uri) : Url() {
                 require(uri.isRelative)
                 RelativeUrl(uri)
             }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RelativeUrl
+
+        return path?.percentDecoded() == other.path?.percentDecoded() &&
+            query == other.query &&
+            fragment == other.fragment
     }
 }
 


### PR DESCRIPTION
Instead of comparing URL to their string representation, compare their components with different rules:

* Scheme is case insensitive.
* Paths must be compared percent-decoded.
* Authority, fragment and query parameters must match.

The reason for this change is that some EPUBs encode unreserved characters which breaks locating a Link from an HREF.

For example both of these are valid relative URLs which point to the same resource:

* `Text/Ces_choses_qu'on_laisse.xhtml`
* `Text/Ces_choses_qu%27on_laisse.xhtml`