### PR TITLE
TTS fixes

### DIFF
--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsPlayer.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsPlayer.kt
@@ -461,6 +461,10 @@ internal class TtsPlayer<S : TtsEngine.Settings, P : TtsEngine.Preferences<P>,
             nextUtterance = contextNow.currentUtterance
         )
         utteranceMutable.value = utteranceWindow.currentUtterance.ttsPlayerUtterance()
+
+        if (playbackMutable.value.state == State.Ended) {
+            playbackMutable.value = playbackMutable.value.copy(state = State.Ready)
+        }
     }
 
     private suspend fun tryLoadNextContext() {
@@ -506,6 +510,7 @@ internal class TtsPlayer<S : TtsEngine.Settings, P : TtsEngine.Preferences<P>,
         playbackMutable.value = playbackMutable.value.copy(
             state = State.Ended
         )
+        playbackJob?.cancel()
     }
 
     private suspend fun playContinuous() {


### PR DESCRIPTION
- Stop indefinitely repeating the last sentence if the `TtsPlayer` is not closed
- Restart playback when going back after the end being reached.