### PR TITLE
Fix applying the PSPDFKit settings on configuration changes

### DIFF
--- a/readium/adapters/pspdfkit/navigator/src/main/java/org/readium/adapter/pspdfkit/navigator/PsPdfKitDocumentFragment.kt
+++ b/readium/adapters/pspdfkit/navigator/src/main/java/org/readium/adapter/pspdfkit/navigator/PsPdfKitDocumentFragment.kt
@@ -160,6 +160,8 @@ public class PsPdfKitDocumentFragment internal constructor(
                     }
                     .onSuccess { resetPdfFragment() }
             }
+        } else {
+            resetPdfFragment()
         }
     }
 


### PR DESCRIPTION
There are some cases (not reproducible in the Test App) where the PSPDFKit settings are not applied when the PDF view is recreated.

For example, it can happen that the RTL page binding is not taken into account after a configuration change triggered by forcing an orientation in the parent `Activity` with `setRequestedOrientation()`.