### PR TITLE
Fix TTS in a fixed-layout EPUB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * Fixed computing the total progression of audiobook locators.
+* Fixed starting the TTS from the current resource in a fixed-layout EPUB.
 
 
 ## [3.0.0-beta.2]

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -1008,12 +1008,19 @@ public class EpubNavigatorFragment internal constructor(
     override suspend fun firstVisibleElementLocator(): Locator? {
         if (!::resourcePager.isInitialized) return null
 
-        val resource = readingOrder[resourcePager.currentItem]
-        return currentReflowablePageFragment?.webView?.findFirstVisibleLocator()
-            ?.copy(
-                href = resource.url(),
-                mediaType = resource.mediaType ?: MediaType.XHTML
-            )
+        return when (viewModel.layout) {
+            EpubLayout.FIXED ->
+                currentLocator.value
+
+            EpubLayout.REFLOWABLE -> {
+                val resource = readingOrder[resourcePager.currentItem]
+                currentReflowablePageFragment?.webView?.findFirstVisibleLocator()
+                    ?.copy(
+                        href = resource.url(),
+                        mediaType = resource.mediaType ?: MediaType.XHTML
+                    )
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed starting the TTS from the current resource in a fixed-layout EPUB.

---

The current visible element API did not return the current locator in an FXL, causing this issue.