### PR TITLE
Improve footnotes handling

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -859,11 +859,12 @@ public class EpubNavigatorFragment internal constructor(
             return true
         }
 
-        override fun shouldFollowFootnoteLink(
+        override fun onFootnoteLinkActivated(
             url: AbsoluteUrl,
             context: HyperlinkNavigator.FootnoteContext
-        ): Boolean =
-            viewModel.shouldFollowFootnoteLink(url, context)
+        ) {
+            viewModel.navigateToUrl(url, context)
+        }
 
         override fun shouldInterceptRequest(webView: WebView, request: WebResourceRequest): WebResourceResponse? =
             viewModel.shouldInterceptRequest(request)

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorViewModel.kt
@@ -173,20 +173,18 @@ internal class EpubNavigatorViewModel(
     /**
      * Intercepts and handles web view navigation to [url].
      */
-    fun navigateToUrl(url: AbsoluteUrl) = viewModelScope.launch {
+    fun navigateToUrl(
+        url: AbsoluteUrl,
+        context: HyperlinkNavigator.LinkContext? = null
+    ) = viewModelScope.launch {
         val link = internalLinkFromUrl(url)
         if (link != null) {
-            if (listener == null || listener.shouldFollowInternalLink(link, null)) {
+            if (listener == null || listener.shouldFollowInternalLink(link, context)) {
                 _events.send(Event.OpenInternalLink(link))
             }
         } else {
             listener?.onExternalLinkActivated(url)
         }
-    }
-
-    fun shouldFollowFootnoteLink(url: AbsoluteUrl, context: HyperlinkNavigator.FootnoteContext): Boolean {
-        val link = internalLinkFromUrl(url) ?: return true
-        return listener?.shouldFollowInternalLink(link, context) ?: true
     }
 
     /**


### PR DESCRIPTION
Use JavaScript `preventDefaultBehavior` to prevent the WebView from loading a footnote link that has already been handled instead of an unreliable workaround.