### PR TITLE
Update KTLint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,35 @@
-[*.{kt,kts}]
+root = true
 
-ktlint_disabled_rules=no-wildcard-imports,max-line-length
+[*]
+ij_continuation_indent_size = 4
+
+[*.swift]
+ij_any_keep_simple_blocks_in_one_line = true
+
+[*.{kt,kts}]
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+ktlint_code_style = intellij_idea
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_max-line-length = disabled
+
+ktlint_standard_annotation-spacing = disabled
+ktlint_standard_block-comment-initial-star-alignment = disabled
+ktlint_standard_class-naming = disabled
+ktlint_standard_comment-wrapping = disabled
+ktlint_standard_discouraged-comment-location = disabled
+ktlint_standard_enum-wrapping = disabled
+ktlint_standard_function-naming = disabled
+ktlint_standard_function-return-type-spacing = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_indent = disabled
+ktlint_standard_kdoc-wrapping = disabled
+ktlint_standard_no-semi = disabled
+ktlint_standard_property-naming = disabled
+ktlint_standard_statement-wrapping = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ktlint_standard_type-parameter-list-spacing = disabled
+ktlint_standard_wrapping = disabled
 
 # Imports must be ordered in lexicographic order without any empty lines in-between.
 # https://github.com/pinterest/ktlint/issues/1236

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ kotlinx-serialization-json = "1.7.3"
 # See https://github.com/google/ksp/releases
 ksp = "2.0.21-1.0.25"
 
-ktlint = "11.5.1"
+ktlint = "12.1.1"
 
 # We cannot upgrade to 1.9.0 as it conflicts with liblcp.
 # See https://github.com/readium/kotlin-toolkit/issues/29

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Deprecated.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Deprecated.kt
@@ -1,5 +1,3 @@
-// ktlint-disable filename
-
 /*
  * Copyright 2020 Readium Foundation. All rights reserved.
  * Use of this source code is governed by the BSD-style license


### PR DESCRIPTION
This PR updates the ktlint gradle plugin to the latest version. In doing so, we are also updating ktlint itself to 1.0.0, and there seems to be a lot of changes there.

Right now, I have only updated the plugin and disabled the rules that currently cause it to error, and there's a lot of them. See https://pinterest.github.io/ktlint/latest/rules/standard/.

Note that `ktlint_code_style` is set to `intellij_idea`. That was the default style before 1.0 so it should match our current. There is an option for `android_studio` too.