### PR TITLE
Fix CBC decryption when originalLength is wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Navigator
+
+* Fixed the value of the `scroll` setting when switching from a reflowable EPUB to a fixed-layout one.
+
+#### LCP
+
+* Fixed `IndexOutOfBoundsException` occurring when an LCP-protected EPUB contains incorrect original lengths in its `META-INF/encryption.xml` file.
+
 
 ## [3.0.1]
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/io/CountingInputStream.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/io/CountingInputStream.kt
@@ -71,6 +71,8 @@ public class CountingInputStream(
             .coerceFirstNonNegative()
             .requireLengthFitInt()
 
+        require(range.first >= count)
+
         if (range.isEmpty()) {
             return ByteArray(0)
         }
@@ -81,7 +83,12 @@ public class CountingInputStream(
         while (skipped != toSkip) {
             skipped += skip(toSkip - skipped)
             if (skipped == 0L) {
-                throw IOException("Could not skip InputStream to read ranges.")
+                if (read() == -1) {
+                    // End reached, range.first was greater or equal to content length
+                    return ByteArray(0)
+                } else {
+                    throw IOException("Could not skip InputStream to read ranges.")
+                }
             }
         }
 


### PR DESCRIPTION
Fixes `IndexOutOfBoundsException` occurring when the `originalLength` reported in `META-INF/encryption.xml` is incorrect.