### PR TITLE
Speed up initialization of `ExoPlayerEngine`

### DIFF
--- a/readium/adapters/exoplayer/audio/src/main/java/org/readium/adapter/exoplayer/audio/ExoPlayerEngine.kt
+++ b/readium/adapters/exoplayer/audio/src/main/java/org/readium/adapter/exoplayer/audio/ExoPlayerEngine.kt
@@ -124,7 +124,7 @@ public class ExoPlayerEngine private constructor(
                 listener = object : Player.Listener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         when (playbackState) {
-                            Player.STATE_READY -> continuation.resume(Unit) { _, _, _ -> }
+                            Player.STATE_READY, Player.STATE_BUFFERING -> continuation.resume(Unit) { _, _, _ -> }
                             Player.STATE_IDLE -> if (player.playerError != null) {
                                 continuation.resume(Unit) { _, _, _ -> }
                             }


### PR DESCRIPTION
We are currently waiting for the first audio resource to buffer before considering the `ExoPlayerEngine` initialized. This can significantly slow down the opening of the audio navigator in case of network latency.

This change will return the audio navigator as soon as we enter the ExoPlayer buffering state. Integrators can then display a spinner to indicate that the audiobook is not yet ready or delay opening the reader to maintain the current behavior.