### PR TITLE
Fix a race condition when initializing the EPUB navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,21 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Navigator
+
+* Fixed a race condition causing EPUB decorations to be applied twice when opening a publication.
+
+
 
 ## [3.0.3]
 
 ### Fixed
+
+#### LCP
 
 * Fixed `IllegalArgumentException` when trying to decrypt the end of a `CbcLcpResource`.
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -672,11 +672,13 @@ public class EpubNavigatorFragment internal constructor(
             RunScriptCommand.Scope.LoadedResources -> {
                 r2PagerAdapter?.mFragments?.forEach { _, fragment ->
                     (fragment as? R2EpubPageFragment)
+                        ?.takeIf { it.isLoaded.value }
                         ?.runJavaScript(command.script)
                 }
             }
-            is RunScriptCommand.Scope.Resource -> {
+            is RunScriptCommand.Scope.LoadedResource -> {
                 loadedFragmentForHref(command.scope.href)
+                    ?.takeIf { it.isLoaded.value }
                     ?.runJavaScript(command.script)
             }
             is RunScriptCommand.Scope.WebView -> {


### PR DESCRIPTION

### Fixed

#### Navigator

* Fixed a race condition causing EPUB decorations to be applied twice when opening a publication.

---

If the application called `applyDecorations()` when a web view is loaded but its resource not yet loaded, it caused the decorations to be applied twice. You can reproduce this by opening several times a publication with a highlight, until you see that the color is darker (two identical decorations on top of each other). I fixed it by only applying the decorations in fully loaded resources.

I also reapply the Readium CSS properties when the web view is loaded, in case they changed since their first static injection in the HTML document.