### PR TITLE
[BOOK-4971] New setting to disable horizontal swipe between resorces.

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt
@@ -111,11 +111,13 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
     var resourceUrl: AbsoluteUrl? = null
 
     internal val scrollModeFlow = MutableStateFlow(false)
+    private val scrollModeDisableSwipePaginationFlow  = MutableStateFlow(true)
 
     /** Indicates that a user text selection is active. */
     internal var isSelecting = false
 
     val scrollMode: Boolean get() = scrollModeFlow.value
+    private val scrollModeDisableSwipePagination: Boolean get() = this.scrollModeDisableSwipePaginationFlow.value
 
     var callback: OnOverScrolledCallback? = null
 
@@ -213,6 +215,9 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
             }
 
             when {
+                // If the user is in scrollMode and has disabled swipe pagination, do nothing.
+                scrollMode && this@R2BasicWebView.scrollModeDisableSwipePagination -> {}
+
                 scrollMode ->
                     goRight(jump = true)
 
@@ -244,6 +249,9 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
             }
 
             when {
+                // If the user is in scrollMode and has disabled swipe pagination, do nothing.
+                scrollMode && this@R2BasicWebView.scrollModeDisableSwipePagination -> {}
+
                 scrollMode ->
                     goLeft(jump = true)
 
@@ -392,7 +400,6 @@ internal open class R2BasicWebView(context: Context, attrs: AttributeSet) : WebV
     fun onDragEnd(eventJson: String): Boolean {
         val event = DragEvent.fromJSON(eventJson)?.takeIf { it.isValid }
             ?: return false
-
         return runBlocking(uiScope.coroutineContext) { listener?.onDragEnd(event) ?: false }
     }
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubDefaults.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubDefaults.kt
@@ -33,6 +33,7 @@ public data class EpubDefaults @ExperimentalReadiumApi constructor(
     val publisherStyles: Boolean? = null,
     val readingProgression: ReadingProgression? = null,
     val scroll: Boolean? = null,
+    val scrollDisableSwipePagination: Boolean? = null,
     val spread: Spread? = null,
     val textAlign: TextAlign? = null,
     val textNormalization: Boolean? = null,

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubPreferences.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubPreferences.kt
@@ -35,6 +35,8 @@ import org.readium.r2.shared.util.Language
  * @param readingProgression Direction of the reading progression across resources.
  * @param scroll Indicates if the overflow of resources should be handled using scrolling
  *   instead of synthetic pagination.
+ * @param scrollDisableSwipePagination Indicates if a user can swipe to change resources while using
+ *   scroll mode (above).
  * @param spread Indicates if the fixed-layout publication should be rendered with a
  *   synthetic spread (dual-page).
  * @param textAlign Page text alignment.
@@ -66,6 +68,7 @@ public data class EpubPreferences @ExperimentalReadiumApi constructor(
     val publisherStyles: Boolean? = null,
     val readingProgression: ReadingProgression? = null,
     val scroll: Boolean? = null,
+    val scrollDisableSwipePagination: Boolean? = null,
     val spread: Spread? = null,
     val textAlign: TextAlign? = null,
     val textColor: Color? = null,
@@ -107,6 +110,7 @@ public data class EpubPreferences @ExperimentalReadiumApi constructor(
             publisherStyles = other.publisherStyles ?: publisherStyles,
             readingProgression = other.readingProgression ?: readingProgression,
             scroll = other.scroll ?: scroll,
+            scrollDisableSwipePagination = other.scrollDisableSwipePagination ?: scrollDisableSwipePagination,
             spread = other.spread ?: spread,
             textAlign = other.textAlign ?: textAlign,
             textColor = other.textColor ?: textColor,

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubPreferencesEditor.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubPreferencesEditor.kt
@@ -340,6 +340,20 @@ public class EpubPreferencesEditor internal constructor(
         )
 
     /**
+     * Indicates if a user can swipe to change resources while using scroll mode (above).
+     *
+     * Only effective when:
+     *  - [scroll] is on
+     */
+    public val scrollDisableSwipePagination: Preference<Boolean> =
+        PreferenceDelegate(
+            getValue = { preferences.scrollDisableSwipePagination },
+            getEffectiveValue = { state.settings.scrollDisableSwipePagination },
+            getIsEffective = { state.settings.scroll },
+            updateValue = { value -> updateValues { it.copy(scrollDisableSwipePagination = value) } }
+        )
+
+    /**
      * Indicates if the fixed-layout publication should be rendered with a synthetic spread
      * (dual-page).
      *

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettings.kt
@@ -53,6 +53,7 @@ public data class EpubSettings @ExperimentalReadiumApi constructor(
     val publisherStyles: Boolean,
     val readingProgression: ReadingProgression,
     val scroll: Boolean,
+    val scrollDisableSwipePagination: Boolean,
     val spread: Spread,
     val textAlign: TextAlign?,
     val textColor: Color?,

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettingsResolver.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubSettingsResolver.kt
@@ -30,6 +30,9 @@ internal class EpubSettingsResolver(
 
         var scroll = preferences.scroll ?: defaults.scroll ?: false
 
+        // TODO: test setting with vertical text
+        val scrollDisableSwipePagination = preferences.scrollDisableSwipePagination ?: defaults.scrollDisableSwipePagination ?: false
+
         // / We disable pagination with vertical text, because CSS columns don't support it properly.
         // / See https://github.com/readium/swift-toolkit/discussions/370
         if (verticalText) {
@@ -54,6 +57,7 @@ internal class EpubSettingsResolver(
             publisherStyles = preferences.publisherStyles ?: defaults.publisherStyles ?: true,
             readingProgression = readingProgression,
             scroll = scroll,
+            scrollDisableSwipePagination = scrollDisableSwipePagination,
             spread = preferences.spread ?: defaults.spread ?: Spread.NEVER,
             textAlign = preferences.textAlign ?: defaults.textAlign,
             textColor = preferences.textColor,

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2EpubPageFragment.kt
@@ -296,6 +296,7 @@ internal class R2EpubPageFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val lifecycleOwner = viewLifecycleOwner
+        // TODO: do I need something like this for scrollDisableSwipePagination?
         lifecycleOwner.lifecycleScope.launch {
             viewModel.isScrollEnabled
                 .flowWithLifecycle(lifecycleOwner.lifecycle)

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
@@ -31,7 +31,6 @@ import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
 import org.readium.r2.navigator.preferences.ReadingProgression;
-import org.readium.r2.shared.ExperimentalReadiumApi;
 
 import java.util.HashMap;
 


### PR DESCRIPTION
A "resource" is an HTML file (i.e. chapter file) in the EPUB world


The next steps is to: have `react-native-readium` utilize this setting in place of its touch interceptor