### PR TITLE
Modified XmlParser to correctly parse CDATA.

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/util/xml/XmlParser.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/xml/XmlParser.kt
@@ -66,7 +66,7 @@ public class XmlParser(
                 }
                 XmlPullParser.CDSECT,
                 XmlPullParser.TEXT,
-                XmlPullParser.ENTITY_REF -> {
+                XmlPullParser.ENTITY_REF, -> {
                     text += parser.text
                 }
             }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/xml/XmlParser.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/xml/XmlParser.kt
@@ -64,7 +64,9 @@ public class XmlParser(
                     val element = buildElement(attributes, children, lang)
                     stack.peek().first.add(element)
                 }
-                XmlPullParser.TEXT, XmlPullParser.ENTITY_REF -> {
+                XmlPullParser.CDSECT,
+                XmlPullParser.TEXT,
+                XmlPullParser.ENTITY_REF -> {
                     text += parser.text
                 }
             }

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/xml/XmlParser.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/xml/XmlParser.kt
@@ -66,7 +66,8 @@ public class XmlParser(
                 }
                 XmlPullParser.CDSECT,
                 XmlPullParser.TEXT,
-                XmlPullParser.ENTITY_REF, -> {
+                XmlPullParser.ENTITY_REF,
+                -> {
                     text += parser.text
                 }
             }

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/xml/XmlParserTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/xml/XmlParserTest.kt
@@ -209,6 +209,21 @@ class XmlParserTest {
     fun `An input with no root raises an exception`() {
         parseXmlString("   \n    \n")
     }
+
+    @Test
+    fun `CDATA parsed rightly`() {
+        val doc = parseXmlString(
+            """
+            <text>
+                pre text <![CDATA["Some text like <, >, & are safe here"]]> post text
+            </text>
+            """.trimIndent()
+        )
+
+        val cdata = doc.children.first() as TextNode
+
+        assertEquals("pre text \"Some text like <, >, & are safe here\" post text", cdata.text.trim())
+    }
 }
 
 @RunWith(RobolectricTestRunner::class)


### PR DESCRIPTION
https://github.com/readium/kotlin-toolkit/issues/627

I have addressed the issue I previously created.  
Fixed a bug where text was incorrectly parsed when `CDATA` was present in the XML file.