### PR TITLE
Add support for TDM Reservation Protocol metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Added
 
+#### Shared
+
+* Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.
+
 #### Navigator
 
 * The `EpubNavigatorFragment.Configuration.disablePageTurnsWhileScrolling` property disables horizontal swipes for navigating to previous or next resources when scroll mode is enabled. When set to `true`, you must implement your own mechanism to move to the next resource (contributed by [@tm-bookshop](https://github.com/readium/kotlin-toolkit/pull/624)).

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
@@ -29,6 +29,9 @@ import org.readium.r2.shared.util.logging.log
 /**
  * https://readium.org/webpub-manifest/schema/metadata.schema.json
  *
+ * @param tdm Publications can indicate whether they allow third parties to use their content for
+ * text and data mining purposes using the [TDM Rep protocol](https://www.w3.org/community/tdmrep/),
+ * as defined in a [W3C Community Group Report](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/).
  * @param otherMetadata Additional metadata for extensions, as a JSON dictionary.
  */
 @Parcelize
@@ -62,6 +65,7 @@ public data class Metadata(
     val duration: Double? = null,
     val numberOfPages: Int? = null,
     val belongsTo: Map<String, List<Collection>> = emptyMap(),
+    val tdm: Tdm? = null,
     val otherMetadata: @WriteWith<JSONParceler> Map<String, Any> = mapOf(),
 ) : JSONable, Parcelable {
 
@@ -97,6 +101,7 @@ public data class Metadata(
         belongsTo: Map<String, List<Collection>> = emptyMap(),
         belongsToCollections: List<Collection> = emptyList(),
         belongsToSeries: List<Collection> = emptyList(),
+        tdm: Tdm? = null,
         otherMetadata: Map<String, Any> = mapOf(),
     ) : this(
         identifier = identifier,
@@ -138,6 +143,7 @@ public data class Metadata(
                 }
             }
             .toMap(),
+        tdm = tdm,
         otherMetadata = otherMetadata
     )
 
@@ -198,6 +204,7 @@ public data class Metadata(
         put("duration", duration)
         put("numberOfPages", numberOfPages)
         putIfNotEmpty("belongsTo", belongsTo)
+        putIfNotEmpty("tdm", tdm)
     }
 
     /**
@@ -298,6 +305,7 @@ public data class Metadata(
             val duration = json.optPositiveDouble("duration", remove = true)
             val numberOfPages = json.optPositiveInt("numberOfPages", remove = true)
 
+            val tdm = Tdm.fromJSON(json.remove("tdm"), warnings)
             val belongsToJson = (
                 json.remove("belongsTo") as? JSONObject
                     ?: json.remove("belongs_to") as? JSONObject
@@ -345,6 +353,7 @@ public data class Metadata(
                 duration = duration,
                 numberOfPages = numberOfPages,
                 belongsTo = belongsTo.toMap(),
+                tdm = tdm,
                 otherMetadata = json.toMap()
             )
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Tdm.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Tdm.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.publication
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import org.json.JSONObject
+import org.readium.r2.shared.InternalReadiumApi
+import org.readium.r2.shared.JSONable
+import org.readium.r2.shared.extensions.optNullableString
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.logging.WarningLogger
+import org.readium.r2.shared.util.logging.log
+
+/**
+ * Publications can indicate whether they allow third parties to use their content for text and data
+ * mining purposes using the [TDM Rep protocol](https://www.w3.org/community/tdmrep/), as defined in
+ * a [W3C Community Group Report](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/).
+ *
+ * https://github.com/readium/webpub-manifest/blob/master/schema/metadata.schema.json
+ *
+ * @param policy URL pointing to a TDM Policy set be the rightsholder.
+ */
+@Parcelize
+public data class Tdm(
+    val reservation: Reservation,
+    val policy: AbsoluteUrl? = null,
+) : JSONable, Parcelable {
+
+    @Parcelize
+    public data class Reservation(public val value: String) : Parcelable {
+
+        public companion object {
+            /**
+             * All TDM rights are reserved. If a TDM Policy is set, TDM Agents MAY use it to get
+             * information on how they can acquire from the rightsholder an authorization to mine
+             * the content.
+             */
+            public val ALL: Reservation = Reservation("all")
+
+            /**
+             * TDM rights are not reserved. TDM agents can mine the content for TDM purposes without
+             * having to contact the rightsholder.
+             */
+            public val NONE: Reservation = Reservation("none")
+        }
+    }
+
+    override fun toJSON(): JSONObject = JSONObject().apply {
+        put("reservation", reservation.value)
+        put("policy", policy?.toString())
+    }
+
+    public companion object {
+
+        /**
+         * Parses a [Tdm] from its RWPM JSON representation.
+         *
+         * If the TDM can't be parsed, a warning will be logged with [warnings].
+         */
+        @OptIn(InternalReadiumApi::class)
+        public fun fromJSON(
+            json: Any?,
+            warnings: WarningLogger? = null,
+        ): Tdm? {
+            if (json !is JSONObject) return null
+            val reservation = json.optNullableString("reservation")?.let { Reservation(it) }
+            val policy = json.optNullableString("policy")?.let { AbsoluteUrl(it) }
+
+            if (reservation == null) {
+                warnings?.log(Tdm::class.java, "no valid reservation in TDM object", json)
+                return null
+            }
+
+            return Tdm(
+                reservation = reservation,
+                policy = policy
+            )
+        }
+    }
+}

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.readium.r2.shared.assertJSONEquals
+import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.Instant
 import org.readium.r2.shared.util.Language
 import org.robolectric.RobolectricTestRunner
@@ -83,6 +84,10 @@ class MetadataTest {
                 ),
                 belongsToCollections = listOf(Contributor(name = "Collection")),
                 belongsToSeries = listOf(Contributor(name = "Series")),
+                tdm = Tdm(
+                    reservation = Tdm.Reservation.ALL,
+                    policy = AbsoluteUrl("http://example.com/tdm-policy")!!
+                ),
                 otherMetadata = mapOf(
                     "other-metadata1" to "value",
                     "other-metadata2" to listOf(42)
@@ -133,6 +138,10 @@ class MetadataTest {
                     "series": "Series",
                     "schema:Periodical": "Periodical",
                     "schema:Newspaper": [ "Newspaper 1", "Newspaper 2" ]
+                },
+                "tdm": {
+                    "reservation": "all",
+                    "policy": "http://example.com/tdm-policy"
                 },
                 "other-metadata1": "value",
                 "other-metadata2": [42]
@@ -255,6 +264,10 @@ class MetadataTest {
                     "series": [{"name": {"und": "Series"}}],
                     "schema:Periodical": [{"name": {"und": "Periodical"}}]
                 },
+                "tdm": {
+                    "reservation": "all",
+                    "policy": "http://example.com/tdm-policy"
+                },
                 "other-metadata1": "value",
                 "other-metadata2": [42]
             }"""
@@ -312,6 +325,10 @@ class MetadataTest {
                 belongsTo = mapOf("schema:Periodical" to listOf(Contributor(name = "Periodical"))),
                 belongsToCollections = listOf(Contributor(name = "Collection")),
                 belongsToSeries = listOf(Contributor(name = "Series")),
+                tdm = Tdm(
+                    reservation = Tdm.Reservation.ALL,
+                    policy = AbsoluteUrl("http://example.com/tdm-policy")!!
+                ),
                 otherMetadata = mapOf(
                     "other-metadata1" to "value",
                     "other-metadata2" to listOf(42)

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/TdmTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/TdmTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.publication
+
+import kotlin.test.assertEquals
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.assertJSONEquals
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TdmTest {
+
+    @Test
+    fun `invalid policy is just ignored`() {
+        assertEquals(
+            Tdm(
+                reservation = Tdm.Reservation.ALL,
+                policy = null
+            ),
+            Tdm.fromJSON(
+                JSONObject(
+                    """{
+                        "reservation": "all",
+                        "policy": "not an URL"
+                    }"""
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `parse minimal JSON`() {
+        assertEquals(
+            Tdm(
+                reservation = Tdm.Reservation.NONE,
+                policy = null
+            ),
+            Tdm.fromJSON(JSONObject("""{ "reservation": "none" }")"""))
+        )
+    }
+
+    @Test
+    fun `parse null JSON`() {
+        Assert.assertNull(Tdm.fromJSON(null))
+    }
+
+    @Test
+    fun `parse full JSON`() {
+        assertEquals(
+            Tdm(
+                reservation = Tdm.Reservation.ALL,
+                policy = AbsoluteUrl("https://policy")!!
+            ),
+            Tdm.fromJSON(
+                JSONObject(
+                    """{
+                        "reservation": "all",
+                        "policy": "https://policy"
+                    }"""
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `get minimal JSON`() {
+        assertJSONEquals(
+            JSONObject("""{ "reservation": "all" }"""),
+            Tdm(
+                reservation = Tdm.Reservation.ALL,
+                policy = null
+            ).toJSON(),
+        )
+    }
+
+    @Test
+    fun `get full JSON`() {
+        assertJSONEquals(
+            JSONObject(
+                """{
+                    "reservation": "all",
+                    "policy": "https://policy"
+                }"""
+            ),
+            Tdm(
+                reservation = Tdm.Reservation.ALL,
+                policy = AbsoluteUrl("https://policy")!!
+            ).toJSON(),
+        )
+    }
+}

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/Constants.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/Constants.kt
@@ -35,6 +35,7 @@ internal object Vocabularies {
     const val ONIX = "http://www.editeur.org/ONIX/book/codelists/current.html#"
     const val SCHEMA = "http://schema.org/"
     const val XSD = "http://www.w3.org/2001/XMLSchema#"
+    const val TDM = "http://www.w3.org/ns/tdmrep#"
 
     const val MSV = "http://www.idpf.org/epub/vocab/structure/magazine/#"
     const val PRISM = "http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#"

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/PropertyDataType.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/PropertyDataType.kt
@@ -14,7 +14,8 @@ internal val PACKAGE_RESERVED_PREFIXES = mapOf(
     "marc" to Vocabularies.MARC,
     "onix" to Vocabularies.ONIX,
     "schema" to Vocabularies.SCHEMA,
-    "xsd" to Vocabularies.XSD
+    "xsd" to Vocabularies.XSD,
+    "tdm" to Vocabularies.TDM,
 )
 
 internal val CONTENT_RESERVED_PREFIXES = mapOf(

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -9,6 +9,7 @@
 
 package org.readium.r2.streamer.parser.epub
 
+import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.Assert.assertNotNull
@@ -19,6 +20,7 @@ import org.readium.r2.shared.publication.Link as SharedLink
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.Presentation
 import org.readium.r2.shared.publication.presentation.presentation
+import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.Instant
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.robolectric.RobolectricTestRunner
@@ -526,5 +528,20 @@ class AccessibilityTest {
                 "any profile"
             )
         )
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class TdmTest {
+    private val epub2Metadata = parsePackageDocument("package/tdm-epub2.opf").metadata
+    private val epub3Metadata = parsePackageDocument("package/tdm-epub3.opf").metadata
+
+    @Test fun `TDM is rightly parsed`() {
+        val expected = Tdm(
+            reservation = Tdm.Reservation.ALL,
+            policy = AbsoluteUrl("https://provider.com/policies/policy.json")!!
+        )
+        assertEquals(expected, epub2Metadata.tdm)
+        assertEquals(expected, epub3Metadata.tdm)
     }
 }

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/tdm-epub2.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/tdm-epub2.opf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="2.0" xml:lang="en">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+
+    <meta name="tdm:reservation" content="1" />
+    <meta name="tdm:policy" content="https://provider.com/policies/policy.json" />
+  </metadata>
+  <manifest>
+    <item id="titlepage" href="titlepage.xhtml"/>
+  </manifest>
+  <spine>
+    <itemref idref="titlepage"/>
+  </spine>
+</package>

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/tdm-epub3.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/tdm-epub3.opf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" prefix="tdm: http://www.w3.org/ns/tdmrep#" unique-identifier="pub-id" version="3.0" xml:lang="en">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+
+    <meta property="tdm:reservation">1</meta>
+    <meta property="tdm:policy">https://provider.com/policies/policy.json</meta>
+  </metadata>
+  <manifest>
+    <item id="titlepage" href="titlepage.xhtml"/>
+  </manifest>
+  <spine>
+    <itemref idref="titlepage"/>
+  </spine>
+</package>


### PR DESCRIPTION

### Added

#### Shared

* Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.