### PR TITLE
Various accessibility metadata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Added
 
+#### Shared
+
+* Support for [accessibility exemption metadata](https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
+* Support for [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) conformance profiles.
+
 #### Navigator
 
 * The `EpubNavigatorFragment.Configuration.disablePageTurnsWhileScrolling` property disables horizontal swipes for navigating to previous or next resources when scroll mode is enabled. When set to `true`, you must implement your own mechanism to move to the next resource (contributed by [@tm-bookshop](https://github.com/readium/kotlin-toolkit/pull/624)).
@@ -19,6 +24,10 @@ All notable changes to this project will be documented in this file. Take a look
 ### Changed
 
 * Jetifier is not required anymore, you can remove `android.enableJetifier=true` from your `gradle.properties` if you were using Readium as a local clone.
+
+#### Shared
+
+* [go-toolkit#92](https://github.com/readium/go-toolkit/issues/92) The accessibility feature `printPageNumbers` is deprecated in favor of `pageNavigation`.
 
 
 ## [3.0.3]

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Accessibility.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Accessibility.kt
@@ -306,9 +306,31 @@ public data class Accessibility(
             public val INDEX: Feature = Feature("index")
 
             /**
+             * The resource includes static page markers, such as those identified by the
+             * doc-pagebreak role (DPUB-ARIA-1.0).
+             *
+             * This value is most commonly used with ebooks for which there is a statically
+             * paginated equivalent, such as a print edition, but it is not required that the page
+             * markers correspond to another work. The markers may exist solely to facilitate
+             * navigation in purely digital works.
+             */
+            public val PAGE_BREAK_MARKERS: Feature = Feature("pageBreakMarkers")
+
+            /**
+             * The resource includes a means of navigating to static page break locations.
+             *
+             * The most common way of providing page navigation in digital publications is through
+             * a page list.
+             */
+            public val PAGE_NAVIGATION: Feature = Feature("pageNavigation")
+
+            /**
              * The work includes equivalent print page numbers. This setting is most commonly used
              * with ebooks for which there is a print equivalent.
+             *
+             * Deprecated: https://github.com/readium/go-toolkit/issues/92
              */
+            @Deprecated("Deprecated in favor of PAGE_NAVIGATION", ReplaceWith("PAGE_NAVIGATION"))
             public val PRINT_PAGE_NUMBERS: Feature = Feature("printPageNumbers")
 
             /**

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Accessibility.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Accessibility.kt
@@ -66,17 +66,47 @@ public data class Accessibility(
 
         public companion object {
 
+            /** EPUB Accessibility 1.0 - WCAG 2.0 Level A */
             public val EPUB_A11Y_10_WCAG_20_A: Profile = Profile(
                 "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a"
             )
 
+            /** EPUB Accessibility 1.0 - WCAG 2.0 Level AA */
             public val EPUB_A11Y_10_WCAG_20_AA: Profile = Profile(
                 "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"
             )
 
+            /** EPUB Accessibility 1.0 - WCAG 2.0 Level AAA */
             public val EPUB_A11Y_10_WCAG_20_AAA: Profile = Profile(
                 "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa"
             )
+
+            /** EPUB Accessibility 1.1 - WCAG 2.0 Level A */
+            public val EPUB_A11Y_11_WCAG_20_A: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.0-a")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.0 Level AA */
+            public val EPUB_A11Y_11_WCAG_20_AA: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.0-aa")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.0 Level AAA */
+            public val EPUB_A11Y_11_WCAG_20_AAA: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.0-aaa")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.1 Level A */
+            public val EPUB_A11Y_11_WCAG_21_A: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.1-a")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.1 Level AA */
+            public val EPUB_A11Y_11_WCAG_21_AA: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.1-aa")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.1 Level AAA */
+            public val EPUB_A11Y_11_WCAG_21_AAA: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.1-aaa")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.2 Level A */
+            public val EPUB_A11Y_11_WCAG_22_A: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.2-a")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.2 Level AA */
+            public val EPUB_A11Y_11_WCAG_22_AA: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.2-aa")
+
+            /** EPUB Accessibility 1.1 - WCAG 2.2 Level AAA */
+            public val EPUB_A11Y_11_WCAG_22_AAA: Profile = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.2-aaa")
 
             public fun Set<Profile>.toJSONArray(): JSONArray =
                 JSONArray(this.map(Profile::uri))

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/AccessibilityTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/AccessibilityTest.kt
@@ -107,6 +107,10 @@ class AccessibilityTest {
                 hazards = setOf(
                     Accessibility.Hazard.FLASHING,
                     Accessibility.Hazard.MOTION_SIMULATION
+                ),
+                exemptions = setOf(
+                    Accessibility.Exemption.EAA_DISPROPORTIONATE_BURDEN,
+                    Accessibility.Exemption.EAA_MICROENTERPRISE
                 )
             ),
             Accessibility.fromJSON(
@@ -122,7 +126,8 @@ class AccessibilityTest {
                     "accessMode": ["auditory", "chartOnVisual"],
                     "accessModeSufficient": [["visual", "tactile"]],
                     "feature": ["readingOrder", "alternativeText"],
-                    "hazard": ["flashing", "motionSimulation"]
+                    "hazard": ["flashing", "motionSimulation"],
+                    "exemption": ["eaa-disproportionate-burden", "eaa-microenterprise"]
                 }"""
                 )
             )
@@ -270,12 +275,40 @@ class AccessibilityTest {
                     Accessibility.Hazard.FLASHING,
                     Accessibility.Hazard.NO_SOUND_HAZARD,
                     Accessibility.Hazard.MOTION_SIMULATION
-                )
+                ),
+                exemptions = emptySet()
             ),
             Accessibility.fromJSON(
                 JSONObject(
                     """{
                     "hazard": ["flashing", "noSoundHazard", "motionSimulation"]
+                }"""
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `exemptions are correctly parsed`() {
+        assertEquals(
+            Accessibility(
+                conformsTo = setOf(),
+                certification = null,
+                summary = null,
+                accessModes = emptySet(),
+                accessModesSufficient = emptySet(),
+                features = emptySet(),
+                hazards = emptySet(),
+                exemptions = setOf(
+                    Accessibility.Exemption.EAA_DISPROPORTIONATE_BURDEN,
+                    Accessibility.Exemption.EAA_FUNDAMENTAL_ALTERATION,
+                    Accessibility.Exemption.EAA_MICROENTERPRISE,
+                )
+            ),
+            Accessibility.fromJSON(
+                JSONObject(
+                    """{
+                    "exemption": ["eaa-disproportionate-burden", "eaa-fundamental-alteration", "eaa-microenterprise"]
                 }"""
                 )
             )
@@ -297,7 +330,8 @@ class AccessibilityTest {
                 "accessMode": ["auditory", "chartOnVisual"],
                 "accessModeSufficient": [["auditory"], ["visual", "tactile"], ["visual"]],
                 "feature": ["readingOrder", "alternativeText"],
-                "hazard": ["flashing", "motionSimulation"]
+                "hazard": ["flashing", "motionSimulation"],
+                "exemption": ["eaa-disproportionate-burden", "eaa-microenterprise"]
             }"""
             ),
             Accessibility(
@@ -330,6 +364,10 @@ class AccessibilityTest {
                 hazards = setOf(
                     Accessibility.Hazard.FLASHING,
                     Accessibility.Hazard.MOTION_SIMULATION
+                ),
+                exemptions = setOf(
+                    Accessibility.Exemption.EAA_DISPROPORTIONATE_BURDEN,
+                    Accessibility.Exemption.EAA_MICROENTERPRISE
                 )
             ).toJSON()
         )

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/AccessibilityAdapter.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/AccessibilityAdapter.kt
@@ -151,11 +151,19 @@ internal class AccessibilityAdapter {
         isWCAG_20_A(value) -> Accessibility.Profile.EPUB_A11Y_10_WCAG_20_A
         isWCAG_20_AA(value) -> Accessibility.Profile.EPUB_A11Y_10_WCAG_20_AA
         isWCAG_20_AAA(value) -> Accessibility.Profile.EPUB_A11Y_10_WCAG_20_AAA
+        value == "EPUB Accessibility 1.1 - WCAG 2.0 Level A" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_20_A
+        value == "EPUB Accessibility 1.1 - WCAG 2.0 Level AA" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_20_AA
+        value == "EPUB Accessibility 1.1 - WCAG 2.0 Level AAA" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_20_AAA
+        value == "EPUB Accessibility 1.1 - WCAG 2.1 Level A" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_21_A
+        value == "EPUB Accessibility 1.1 - WCAG 2.1 Level AA" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_21_AA
+        value == "EPUB Accessibility 1.1 - WCAG 2.1 Level AAA" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_21_AAA
+        value == "EPUB Accessibility 1.1 - WCAG 2.2 Level A" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_22_A
+        value == "EPUB Accessibility 1.1 - WCAG 2.2 Level AA" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_22_AA
+        value == "EPUB Accessibility 1.1 - WCAG 2.2 Level AAA" -> Accessibility.Profile.EPUB_A11Y_11_WCAG_22_AAA
         else -> null
     }
 
     private fun isWCAG_20_A(value: String) = value in setOf(
-        "EPUB Accessibility 1.1 - WCAG 2.0 Level A",
         "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
         "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
         "https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
@@ -163,7 +171,6 @@ internal class AccessibilityAdapter {
     )
 
     private fun isWCAG_20_AA(value: String) = value in setOf(
-        "EPUB Accessibility 1.1 - WCAG 2.0 Level AA",
         "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
         "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
         "https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
@@ -171,7 +178,6 @@ internal class AccessibilityAdapter {
     )
 
     private fun isWCAG_20_AAA(value: String) = value in setOf(
-        "EPUB Accessibility 1.1 - WCAG 2.0 Level AAA",
         "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
         "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
         "https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/AccessibilityAdapter.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/AccessibilityAdapter.kt
@@ -39,6 +39,11 @@ internal class AccessibilityAdapter {
             .map { Accessibility.Hazard(it.value) }
             .toSet()
 
+        val exemptions = itemsHolder
+            .adapt { it.takeAllWithProperty(Vocabularies.A11Y + "exemption") }
+            .map { Accessibility.Exemption(it.value) }
+            .toSet()
+
         val certification = itemsHolder
             .adapt(::adaptCertification)
 
@@ -52,7 +57,8 @@ internal class AccessibilityAdapter {
                 accessModes = accessModes,
                 accessModesSufficient = accessModesSufficient,
                 features = features,
-                hazards = hazards
+                hazards = hazards,
+                exemptions = exemptions
             )
             accessibility to itemsHolder.remainingItems
         }

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -443,10 +443,14 @@ class AccessibilityTest {
 
     @Test fun `conformsTo contains WCAG profiles and only them`() {
         assertThat(epub2Metadata.accessibility?.conformsTo).containsExactlyInAnyOrder(
-            Accessibility.Profile.EPUB_A11Y_10_WCAG_20_A
+            Accessibility.Profile.EPUB_A11Y_10_WCAG_20_A,
+            Accessibility.Profile.EPUB_A11Y_11_WCAG_20_AAA,
+            Accessibility.Profile.EPUB_A11Y_11_WCAG_21_AA,
         )
         assertThat(epub3Metadata.accessibility?.conformsTo).containsExactlyInAnyOrder(
-            Accessibility.Profile.EPUB_A11Y_10_WCAG_20_A
+            Accessibility.Profile.EPUB_A11Y_10_WCAG_20_A,
+            Accessibility.Profile.EPUB_A11Y_11_WCAG_20_AAA,
+            Accessibility.Profile.EPUB_A11Y_11_WCAG_21_AA,
         )
     }
 

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -485,6 +485,21 @@ class AccessibilityTest {
             )
     }
 
+    @Test fun `exemptions are rightly parsed`() {
+        assertThat(epub2Metadata.accessibility?.exemptions)
+            .containsExactlyInAnyOrder(
+                Accessibility.Exemption.EAA_MICROENTERPRISE,
+                Accessibility.Exemption.EAA_FUNDAMENTAL_ALTERATION,
+                Accessibility.Exemption.EAA_DISPROPORTIONATE_BURDEN,
+            )
+        assertThat(epub3Metadata.accessibility?.exemptions)
+            .containsExactlyInAnyOrder(
+                Accessibility.Exemption.EAA_MICROENTERPRISE,
+                Accessibility.Exemption.EAA_FUNDAMENTAL_ALTERATION,
+                Accessibility.Exemption.EAA_DISPROPORTIONATE_BURDEN,
+            )
+    }
+
     @Test fun `accessModes are rightly parsed`() {
         assertThat(epub2Metadata.accessibility?.accessModes)
             .containsExactlyInAnyOrder(

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub2.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub2.opf
@@ -22,6 +22,10 @@
     <meta name="a11y:certifiedBy" content="Accessibility Testers Group"/>
     <meta name="a11y:certifierCredential" content="DAISY OK"/>
     <meta name="a11y:certifierReport" content="https://example.com/a11y-report/"/>
+
+    <meta name="a11y:exemption" content="eaa-microenterprise"/>
+    <meta name="a11y:exemption" content="eaa-fundamental-alteration"/>
+    <meta name="a11y:exemption" content="eaa-disproportionate-burden"/>
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml"/>

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub2.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub2.opf
@@ -5,6 +5,8 @@
 
     <dc:conformsTo>any profile</dc:conformsTo>
     <dc:conformsTo>http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</dc:conformsTo>
     <meta name="schema:accessibilitySummary" content="The publication contains structural and page navigation."/>
 
     <meta name="schema:accessMode" content="textual"/>

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub3.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub3.opf
@@ -4,6 +4,8 @@
     <dc:title>Alice's Adventures in Wonderland</dc:title>
 
     <dc:conformsTo>any profile</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</dc:conformsTo>
     <link href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a" rel="dcterms:conformsTo"/>
     <meta property="schema:accessibilitySummary">The publication contains structural and page navigation.</meta>
 

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub3.opf
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/accessibility-epub3.opf
@@ -26,6 +26,9 @@
     <link rel="a11y:certifierReport" refines="#certifier2" href="https://example.com/fakereport"/>
     <link rel="a11y:certifierReport" refines="#certifier" href="https://example.com/a11y-report/"/>
 
+    <meta property="a11y:exemption">eaa-microenterprise</meta>
+    <meta property="a11y:exemption">eaa-fundamental-alteration</meta>
+    <meta property="a11y:exemption">eaa-disproportionate-burden</meta>
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml"/>


### PR DESCRIPTION

### Added

#### Shared

* Support for [accessibility exemption metadata](https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
* Support for [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) conformance profiles.

### Changed

#### Shared

* [go-toolkit#92](https://github.com/readium/go-toolkit/issues/92) The accessibility feature `printPageNumbers` is deprecated in favor of `pageNavigation`.