### PR TITLE
fix: webpub EPUBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * [go-toolkit#92](https://github.com/readium/go-toolkit/issues/92) The accessibility feature `printPageNumbers` is deprecated in favor of `pageNavigation`.
 
+### Fixed
+
+* Fixed support of Readium Web Publication packages conforming to the EPUB profile (contributed by [@ddfreiling](https://github.com/readium/kotlin-toolkit/pull/642)).
+
 
 ## [3.0.3]
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
@@ -42,7 +42,6 @@ internal fun Resource.injectHtml(
         var content = bytes.toString(mediaType.charset ?: Charsets.UTF_8).trim()
         val injectables = mutableListOf<String>()
 
-        // FIX: Default to reflowable layout
         if (publication.metadata.presentation.layout == EpubLayout.FIXED) {
             injectables.add(
                 script(baseHref.resolve(Url("readium/scripts/readium-fixed.js")!!))

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/HtmlInjector.kt
@@ -42,7 +42,12 @@ internal fun Resource.injectHtml(
         var content = bytes.toString(mediaType.charset ?: Charsets.UTF_8).trim()
         val injectables = mutableListOf<String>()
 
-        if (publication.metadata.presentation.layout == EpubLayout.REFLOWABLE) {
+        // FIX: Default to reflowable layout
+        if (publication.metadata.presentation.layout == EpubLayout.FIXED) {
+            injectables.add(
+                script(baseHref.resolve(Url("readium/scripts/readium-fixed.js")!!))
+            )
+        } else {
             content = try {
                 css.injectHtml(content)
             } catch (e: Exception) {
@@ -53,10 +58,6 @@ internal fun Resource.injectHtml(
                 script(
                     baseHref.resolve(Url("readium/scripts/readium-reflowable.js")!!)
                 )
-            )
-        } else {
-            injectables.add(
-                script(baseHref.resolve(Url("readium/scripts/readium-fixed.js")!!))
             )
         }
 

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
@@ -47,11 +47,16 @@ import timber.log.Timber
 
 /**
  * Parses any Readium Web Publication package or manifest, e.g. WebPub, Audiobook, DiViNa, LCPDF...
+ *
+ * @param epubReflowablePositionsStrategy Strategy used to calculate the number
+ * of positions in a reflowable resource of a web publication conforming to the
+ * EPUB profile.
  */
 public class ReadiumWebPubParser(
     private val context: Context? = null,
     private val httpClient: HttpClient,
     private val pdfFactory: PdfDocumentFactory<*>?,
+    private val epubReflowablePositionsStrategy: EpubPositionsService.ReflowableStrategy = EpubPositionsService.ReflowableStrategy.recommended,
 ) : PublicationParser {
 
     override suspend fun parse(
@@ -99,7 +104,7 @@ public class ReadiumWebPubParser(
                 manifest.conformsTo(Publication.Profile.DIVINA) ->
                     PerResourcePositionsService.createFactory(MediaType("image/*")!!)
                 manifest.conformsTo(Publication.Profile.EPUB) ->
-                    EpubPositionsService.createFactory(EpubPositionsService.ReflowableStrategy.recommended)
+                    EpubPositionsService.createFactory(epubReflowablePositionsStrategy)
                 else ->
                     WebPositionsService.createFactory(httpClient)
             }

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
@@ -42,6 +42,7 @@ import org.readium.r2.shared.util.resource.Resource
 import org.readium.r2.shared.util.resource.SingleResourceContainer
 import org.readium.r2.streamer.parser.PublicationParser
 import org.readium.r2.streamer.parser.audio.AudioLocatorService
+import org.readium.r2.streamer.parser.epub.EpubPositionsService
 import timber.log.Timber
 
 /**
@@ -97,6 +98,8 @@ public class ReadiumWebPubParser(
                     pdfFactory?.let { LcpdfPositionsService.create(it) }
                 manifest.conformsTo(Publication.Profile.DIVINA) ->
                     PerResourcePositionsService.createFactory(MediaType("image/*")!!)
+                manifest.conformsTo(Publication.Profile.EPUB) ->
+                    EpubPositionsService.createFactory(EpubPositionsService.ReflowableStrategy.recommended)
                 else ->
                     WebPositionsService.createFactory(httpClient)
             }


### PR DESCRIPTION
Fixes #641

Unlike swift-toolkit, this one did not set the correct `positionsServiceFactory` for WebPubs which conform to EPUB (regular EPUBs packaged as WebPub).

See https://github.com/readium/swift-toolkit/blob/develop/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift#L108-L109

There also seemed to be an issue with FXL being the default layout, if none set via metadata.presentation. This does not seem to be the case with other toolkits and broke CSS/JS injections for our WebPubs. @mickael-menu maybe there is a smarter way to fix this?