### PR TITLE
Update the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: File a bug report to help improve the Readium toolkit
-title: "[Bug] "
-labels: ["bug", "triage"]
+labels: ["triage"]
+type: "Bug"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Update the bug report issue template to automatically set the `Bug` type instead of a `bug` label.