### PR TITLE
fix: corrected typo 'spread-node' to 'spread-none'

### DIFF
--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/ResourceAdapter.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/ResourceAdapter.kt
@@ -162,7 +162,7 @@ internal class ResourceAdapter(
             }?.let { linkProperties["page"] = it }
             //  Spread
             when (property) {
-                Vocabularies.RENDITION + "spread-node" -> "none"
+                Vocabularies.RENDITION + "spread-none" -> "none"
                 Vocabularies.RENDITION + "spread-auto" -> "auto"
                 Vocabularies.RENDITION + "spread-landscape" -> "landscape"
                 Vocabularies.RENDITION + "spread-portrait",


### PR DESCRIPTION
The incorrect rendition property 'spread-node' has been fixed to the correct 'spread-none' to ensure proper parsing of EPUB rendition metadata.