### PR TITLE
Migrate to Central Portal for Maven Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -27,17 +27,15 @@ You are ready to release a new version of the Kotlin toolkit? Great, follow thes
     * Add an APK to the release page **with LCP enabled**.
 6. Publish to Maven Central.
     1. Verify that the [`Publish` workflow](https://github.com/readium/kotlin-toolkit/actions/workflows/publish.yml) successfully pushed and closed the release to Maven Central.
-    2. Sign in to https://s01.oss.sonatype.org/
-    3. Verify the content of the staging repository.
-    4. Release the staging repository.
+    2. Sign in to https://central.sonatype.com/publishing/deployments
+    3. Verify the content of the components.
+    4. Publish the components
 7. Check that the new modules can be imported in an Android project from Maven Central.
 8. Merge `develop` into `main`.
 
 ### Publishing to Maven Central manually
 
 If the `Publish` workflow fails, you may need to publish to Maven Central manually.
-
-[The Sonatype issue for Readium is located here](https://issues.sonatype.org/browse/OSSRH-85964).
 
 #### With the new vanniktech's Maven publish plugin
 
@@ -46,24 +44,8 @@ If the `Publish` workflow fails, you may need to publish to Maven Central manual
     ```
     ./gradlew publishToMavenCentral --no-configuration-cache
     ```
-3. Sign in to https://s01.oss.sonatype.org/
-4. Publish manually the previously closed Staging repository
-
-### (Deprecated) With the official Maven publish plugin
-
-1. Make sure you have the secrets in `local.properties`.
-2. Run:
-    ```
-    ./gradlew clean assembleRelease
-    ./gradlew androidSourcesJar javadocJar
-    ./gradlew publishReleasePublicationToSonatypeRepository closeSonatypeStagingRepository
-    ```
-3. Sign in to https://s01.oss.sonatype.org/
-4. Publish manually the previously closed Staging repository
-
-Note that [you can't run the gradlew commands separately](https://github.com/gradle-nexus/publish-plugin#publishing-and-closing-in-different-gradle-invocations), otherwise you get this error:
-
-> No staging repository with name sonatype created
+3. Sign in to https://central.sonatype.com/publishing/deployments
+4. Publish manually the components
 
 ## Troubleshooting
 

--- a/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
@@ -89,12 +89,6 @@ mavenPublishing {
                 name.set("Quentin Gliosca")
                 email.set("quentin.gliosca@gmail.com")
             }
-
-            developer {
-                id.set("username")
-                name.set("User Name")
-                url.set("https://github.com/username/")
-            }
         }
         scm {
             url.set("https://github.com/readium/kotlin-toolkit")
@@ -103,6 +97,6 @@ mavenPublishing {
         }
     }
 
-    publishToMavenCentral(SonatypeHost.S01)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 }


### PR DESCRIPTION
OSSRH is now deprecated and we need to migrate to the new Central Portal.

https://central.sonatype.org/faq/what-happened-to-issues-sonatype-org
https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh