### PR TITLE
Upgrade to kotlinx-datetime 0.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ junit = "4.13.2"
 
 kotlinx-coroutines = "1.10.2"
 kotlinx-coroutines-test = "1.10.2"
-kotlinx-datetime = "0.6.2"
+kotlinx-datetime = "0.7.0"
 kotlinx-serialization-json = "1.8.1"
 
 # Make sure to align with the Kotlin version.

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Instant.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Instant.kt
@@ -1,10 +1,11 @@
-@file:OptIn(InternalReadiumApi::class)
+@file:OptIn(InternalReadiumApi::class, ExperimentalTime::class)
 
 package org.readium.r2.shared.util
 
 import android.os.Parcel
 import android.os.Parcelable
-import kotlinx.datetime.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -29,10 +30,10 @@ import org.readium.r2.shared.extensions.tryOrNull
  * A moment in time.
  */
 @Parcelize
-@TypeParceler<kotlinx.datetime.Instant, InstantParceler>()
+@TypeParceler<kotlin.time.Instant, InstantParceler>()
 @Serializable(with = InstantSerializer::class)
 public class Instant private constructor(
-    private val value: kotlinx.datetime.Instant,
+    private val value: kotlin.time.Instant,
 ) : Parcelable, Comparable<Instant> {
     public companion object {
         /**
@@ -41,20 +42,20 @@ public class Instant private constructor(
          * Returns null if it can't be parsed.
          */
         public fun parse(input: String): Instant? {
-            val instant = tryOrNull { kotlinx.datetime.Instant.parse(input) }
+            val instant = tryOrNull { kotlin.time.Instant.parse(input) }
                 ?: tryOrNull { LocalDateTime.parse(input).toInstant(TimeZone.UTC) }
                 ?: tryOrNull { LocalDate.parse(input).atStartOfDayIn(TimeZone.UTC) }
 
             return instant?.let { Instant(it) }
         }
 
-        public fun fromKotlinInstant(value: kotlinx.datetime.Instant): Instant = Instant(value)
+        public fun fromKotlinInstant(value: kotlin.time.Instant): Instant = Instant(value)
 
         public fun fromJavaDate(date: java.util.Date): Instant =
-            Instant(kotlinx.datetime.Instant.fromEpochMilliseconds(date.time))
+            Instant(kotlin.time.Instant.fromEpochMilliseconds(date.time))
 
         public fun fromEpochMilliseconds(milliseconds: Long): Instant =
-            Instant(kotlinx.datetime.Instant.fromEpochMilliseconds(milliseconds))
+            Instant(kotlin.time.Instant.fromEpochMilliseconds(milliseconds))
 
         /**
          * Returns an [Instant] representing the current moment in time.
@@ -62,7 +63,7 @@ public class Instant private constructor(
         public fun now(): Instant = Instant(Clock.System.now())
     }
 
-    public fun toKotlinInstant(): kotlinx.datetime.Instant = value
+    public fun toKotlinInstant(): kotlin.time.Instant = value
 
     public fun toJavaDate(): java.util.Date = java.util.Date(value.toEpochMilliseconds())
 
@@ -83,12 +84,12 @@ public class Instant private constructor(
 }
 
 @InternalReadiumApi
-private object InstantParceler : Parceler<kotlinx.datetime.Instant> {
+private object InstantParceler : Parceler<kotlin.time.Instant> {
 
-    override fun create(parcel: Parcel): kotlinx.datetime.Instant =
-        kotlinx.datetime.Instant.fromEpochMilliseconds(parcel.readLong())
+    override fun create(parcel: Parcel): kotlin.time.Instant =
+        kotlin.time.Instant.fromEpochMilliseconds(parcel.readLong())
 
-    override fun kotlinx.datetime.Instant.write(parcel: Parcel, flags: Int) {
+    override fun kotlin.time.Instant.write(parcel: Parcel, flags: Int) {
         parcel.writeLong(toEpochMilliseconds())
     }
 }


### PR DESCRIPTION
Close #687 
The `kotlinx.datetime.Instant` has been deprecated and replaced by `kotlin.time.Instant`. This commit updates the `Instant` utility class to use the new type and upgrades the `kotlinx-datetime` library to version 0.7.0.