### PR TITLE
fix(tts): add missing supported timeline command to TtsSessionAdapter

### DIFF
--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
@@ -157,7 +157,8 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
                 COMMAND_SET_SPEED_AND_PITCH,
                 COMMAND_GET_CURRENT_MEDIA_ITEM,
                 COMMAND_GET_METADATA,
-                COMMAND_GET_TEXT
+                COMMAND_GET_TEXT,
+                COMMAND_GET_TIMELINE
             ).build()
 
     override fun getApplicationLooper(): Looper {

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
@@ -458,11 +458,16 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
 
     override fun getCurrentTimeline(): Timeline {
         // MediaNotificationManager requires a non-empty timeline to start foreground playing.
-        return TtsTimeline(mediaItems)
+        // Report a single-item timeline in order to show a notification, but without skip buttons.
+        return if (mediaItems.isNotEmpty()) {
+            TtsTimeline(listOf(mediaItems[currentMediaItemIndex]))
+        } else {
+            TtsTimeline(emptyList())
+        }
     }
 
     override fun getCurrentPeriodIndex(): Int {
-        return ttsPlayer.utterance.value.position.resourceIndex
+        return 0
     }
 
     @Deprecated("Deprecated in Java", ReplaceWith("currentMediaItemIndex"))
@@ -471,7 +476,8 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
     }
 
     override fun getCurrentMediaItemIndex(): Int {
-        return ttsPlayer.utterance.value.position.resourceIndex
+        // Reporting a single-item timeline, so index is always 0.
+        return 0
     }
 
     @Deprecated("Deprecated in Java", ReplaceWith("nextMediaItemIndex"))
@@ -576,7 +582,7 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
 
     override fun isCurrentMediaItemLive(): Boolean {
         val timeline = currentTimeline
-        return !timeline.isEmpty && timeline.getWindow(currentMediaItemIndex, window).isLive()
+        return !timeline.isEmpty && timeline.getWindow(currentMediaItemIndex, window).isLive
     }
 
     override fun getCurrentLiveOffset(): Long {


### PR DESCRIPTION
without this command the session-adapter didn't properly report the current timeline to a media3.MediaSession