### PR TITLE
Update dependencies and JVM target

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.20" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xannotation-default-target=param-property")
         jvmTarget = JvmTarget.JVM_11
-        // allWarningsAsErrors = true
+        allWarningsAsErrors = true
     }
 }
 

--- a/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.SonatypeHost
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     // FIXME: For now, we cannot use the versions catalog in precompiled scripts: https://github.com/gradle/gradle/issues/15383
@@ -21,14 +22,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-        allWarningsAsErrors = true
     }
 
     testOptions {
@@ -50,10 +46,17 @@ android {
 
 kotlin {
     explicitApi()
+    
+    compilerOptions {
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
+        jvmTarget = JvmTarget.JVM_11
+        // allWarningsAsErrors = true
+    }
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    //noinspection UseTomlInstead
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 }
 
 mavenPublishing {

--- a/demos/navigator/build.gradle.kts
+++ b/demos/navigator/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     kotlin("android")
@@ -10,7 +12,7 @@ android {
     compileSdk = (property("android.compileSdk") as String).toInt()
 
     defaultConfig {
-        minSdk = 23
+        minSdk = (property("android.minSdk") as String).toInt()
         targetSdk = (property("android.targetSdk") as String).toInt()
 
         applicationId = "org.readium.navigator.demo"
@@ -22,14 +24,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
-    }
+
     buildFeatures {
         viewBinding = true
         compose = true
@@ -57,6 +56,14 @@ android {
         }
     }
     namespace = "org.readium.demo.navigator"
+}
+
+kotlin {
+
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+    }
 }
 
 dependencies {

--- a/demos/navigator/src/main/java/org/readium/demo/navigator/decorations/CustomDecorationStyles.kt
+++ b/demos/navigator/src/main/java/org/readium/demo/navigator/decorations/CustomDecorationStyles.kt
@@ -26,7 +26,7 @@ import org.readium.r2.shared.publication.epub.pageList
  *
  * This is an example of a custom Decoration Style declaration.
  */
-data class DecorationStyleAnnotationMark(@ColorInt val tint: Int) : Decoration.Style
+data class DecorationStyleAnnotationMark(@param:ColorInt val tint: Int) : Decoration.Style
 
 /**
  * Decoration Style for a page number label.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 kotlin = "2.2.20"
-agp = "8.13.0"
+agp = "8.11.1"
 desugar_jdk_libs = "2.1.5"
 gradle-maven-publish-plugin = "0.32.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,41 +1,41 @@
 [versions]
 
-kotlin = "2.1.21"
-agp = "8.10.1"
+kotlin = "2.2.20"
+agp = "8.13.0"
 desugar_jdk_libs = "2.1.5"
 gradle-maven-publish-plugin = "0.32.0"
 
-androidx-activity = "1.10.1"
+androidx-activity = "1.11.0"
 androidx-annotation = "1.9.1"
-androidx-appcompat = "1.7.0"
-androidx-browser = "1.8.0"
+androidx-appcompat = "1.7.1"
+androidx-browser = "1.9.0"
 androidx-cardview = "1.0.0"
-androidx-compose-animation = "1.8.2"
-androidx-compose-foundation = "1.8.2"
-androidx-compose-material = "1.8.2"
+androidx-compose-animation = "1.9.2"
+androidx-compose-foundation = "1.9.2"
+androidx-compose-material = "1.9.2"
 androidx-compose-material-icons = "1.7.8"
-androidx-compose-material3 = "1.3.2"
-androidx-compose-runtime = "1.8.2"
-androidx-compose-ui = "1.8.2"
+androidx-compose-material3 = "1.4.0"
+androidx-compose-runtime = "1.9.2"
+androidx-compose-ui = "1.9.2"
 androidx-constraintlayout = "2.2.1"
-androidx-core = "1.16.0"
+androidx-core = "1.17.0"
 androidx-datastore = "1.1.7"
-androidx-fragment-ktx = "1.8.7"
+androidx-fragment-ktx = "1.8.9"
 androidx-legacy = "1.0.0"
-androidx-lifecycle = "2.9.0"
-androidx-media3 = "1.7.1"
-androidx-navigation = "2.9.0"
+androidx-lifecycle = "2.9.4"
+androidx-media3 = "1.8.0"
+androidx-navigation = "2.9.5"
 androidx-paging = "3.3.6"
 androidx-recyclerview = "1.4.0"
-androidx-room = "2.7.1"
+androidx-room = "2.8.1"
 androidx-viewpager2 = "1.1.0"
-androidx-webkit = "1.13.0"
+androidx-webkit = "1.14.0"
 
-assertj = "3.27.3"
+assertj = "3.27.6"
 
 dokka = "1.9.20"
 
-google-material = "1.12.0"
+google-material = "1.13.0"
 
 joda-time = "2.14.0"
 #Do not upgrade without fixing unit tests in HtmlResourceContentIteratorTest and regression testing
@@ -52,7 +52,7 @@ kotlinx-collections-immutable = "0.4.0"
 
 # Make sure to align with the Kotlin version.
 # See https://github.com/google/ksp/releases
-ksp = "2.1.21-2.0.1"
+ksp = "2.2.20-2.0.3"
 
 ktlint = "12.1.1"
 
@@ -62,8 +62,8 @@ pdf-viewer = "3.2.8"
 picasso = "2.8"
 pspdfkit = "8.4.1"
 
-robolectric = "4.14.1"
-mockk = "1.14.2"
+robolectric = "4.16"
+mockk = "1.14.6"
 
 timber = "5.0.1"
 

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -11,10 +11,12 @@ plugins {
 
 android {
     namespace = "org.readium.r2.lcp"
+}
 
-    kotlinOptions {
+kotlin {
+    compilerOptions {
         // See https://github.com/readium/kotlin-toolkit/pull/525#issuecomment-2300084041
-        freeCompilerArgs = freeCompilerArgs + ("-Xconsistent-data-class-copy-visibility")
+        freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
     }
 }
 

--- a/readium/navigator/build.gradle.kts
+++ b/readium/navigator/build.gradle.kts
@@ -17,8 +17,13 @@ android {
     }
 
     kotlinOptions {
+    }
+}
+
+kotlin {
+    compilerOptions {
         // See https://github.com/readium/kotlin-toolkit/pull/525#issuecomment-2300084041
-        freeCompilerArgs = freeCompilerArgs + ("-Xconsistent-data-class-copy-visibility")
+        freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
     }
 }
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/extensions/Extensions.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/extensions/Extensions.kt
@@ -14,7 +14,7 @@ import androidx.core.content.ContextCompat
 /** returns true if the resolved layout direction of the content view in this
  * activity is ViewCompat.LAYOUT_DIRECTION_RTL. Otherwise false. */
 internal fun Activity.layoutDirectionIsRTL(): Boolean {
-    return findViewById<View?>(android.R.id.content).layoutDirection == View.LAYOUT_DIRECTION_RTL
+    return findViewById<View>(android.R.id.content).layoutDirection == View.LAYOUT_DIRECTION_RTL
 }
 
 @ColorInt

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
@@ -31,6 +31,7 @@ import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
 import org.readium.r2.navigator.preferences.ReadingProgression;
+import org.readium.r2.shared.InternalReadiumApi;
 
 import java.util.HashMap;
 
@@ -44,7 +45,8 @@ import java.util.HashMap;
  * <code>OnPageChangeListener</code>s so that clients can be agnostic to layout direction and
  * modifications are kept internal to <code>RtlViewPager</code>.
  */
-class R2RTLViewPager extends ViewPager {
+@InternalReadiumApi
+public class R2RTLViewPager extends ViewPager {
     public ReadingProgression direction = ReadingProgression.LTR;
     private int mLayoutDirection = ViewCompat.LAYOUT_DIRECTION_LTR;
     private HashMap<OnPageChangeListener, ReversingOnPageChangeListener> mPageChangeListeners = new HashMap<>();

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2RTLViewPager.java
@@ -59,9 +59,9 @@ class R2RTLViewPager extends ViewPager {
     @Override
     public void onRtlPropertiesChanged(int layoutDirection) {
         super.onRtlPropertiesChanged(layoutDirection);
-        int viewCompatLayoutDirection = layoutDirection == View.LAYOUT_DIRECTION_RTL  ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR;
+        int viewCompatLayoutDirection = layoutDirection == View.LAYOUT_DIRECTION_RTL  ? View.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR;
         if (direction == ReadingProgression.RTL) {
-            viewCompatLayoutDirection = ViewCompat.LAYOUT_DIRECTION_RTL;
+            viewCompatLayoutDirection = View.LAYOUT_DIRECTION_RTL;
         }
         if (viewCompatLayoutDirection != mLayoutDirection) {
             PagerAdapter adapter = super.getAdapter();

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2ViewPager.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/pager/R2ViewPager.kt
@@ -14,9 +14,12 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
 import org.readium.r2.navigator.BuildConfig.DEBUG
+import org.readium.r2.shared.InternalReadiumApi
 import timber.log.Timber
 
-internal class R2ViewPager : R2RTLViewPager {
+// See https://youtrack.jetbrains.com/issue/KTLC-271 for visibility issue.
+@InternalReadiumApi
+public class R2ViewPager : R2RTLViewPager {
 
     internal enum class PublicationType {
         EPUB,
@@ -29,8 +32,8 @@ internal class R2ViewPager : R2RTLViewPager {
 
     internal lateinit var publicationType: PublicationType
 
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+    internal constructor(context: Context) : super(context)
+    internal constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 
     override fun setCurrentItem(item: Int) {
         super.setCurrentItem(item, false)

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/AudioFocusManager.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/AudioFocusManager.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.AudioManager.OnAudioFocusChangeListener
+import android.os.Build
 import android.os.Handler
 import androidx.annotation.IntDef
 import androidx.annotation.RequiresApi
@@ -30,7 +31,6 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.Log
 import androidx.media3.common.util.Util
 import java.util.Objects
-import org.readium.navigator.media.tts.session.AudioFocusManager.PlayerControl
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 /** Manages requesting and responding to changes in audio focus.
@@ -186,7 +186,7 @@ internal class AudioFocusManager(
             return PLAYER_COMMAND_PLAY_WHEN_READY
         }
         val requestResult =
-            if (Util.SDK_INT >= 26) requestAudioFocusV26() else requestAudioFocusDefault()
+            if (Build.VERSION.SDK_INT >= 26) requestAudioFocusV26() else requestAudioFocusDefault()
         return if (requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
             setAudioFocusState(AUDIO_FOCUS_STATE_HAVE_FOCUS)
             PLAYER_COMMAND_PLAY_WHEN_READY
@@ -200,7 +200,7 @@ internal class AudioFocusManager(
         if (audioFocusState == AUDIO_FOCUS_STATE_NO_FOCUS) {
             return
         }
-        if (Util.SDK_INT >= 26) {
+        if (Build.VERSION.SDK_INT >= 26) {
             abandonAudioFocusV26()
         } else {
             abandonAudioFocusDefault()
@@ -407,11 +407,8 @@ internal class AudioFocusManager(
                     ->
                         AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
                     C.USAGE_ASSISTANT ->
-                        if (Util.SDK_INT >= 19) {
-                            AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
-                        } else {
-                            AUDIOFOCUS_GAIN_TRANSIENT
-                        }
+                        AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
+
                     C.USAGE_ASSISTANCE_ACCESSIBILITY -> {
                         if (audioAttributes.contentType == C.AUDIO_CONTENT_TYPE_SPEECH) {
                             // Voice shouldn't be interrupted by other playback.

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/StreamVolumeManager.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/StreamVolumeManager.kt
@@ -20,11 +20,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
+import android.os.Build
 import android.os.Handler
 import androidx.media3.common.C
 import androidx.media3.common.util.Assertions
 import androidx.media3.common.util.Log
-import androidx.media3.common.util.Util
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 /** A manager that wraps [AudioManager] to control/listen audio stream volume.  */
@@ -82,7 +82,7 @@ internal class StreamVolumeManager(context: Context, eventHandler: Handler, list
      * Gets the minimum volume for the current audio stream. It can be changed if [ ][.setStreamType] is called.
      */
     val minVolume: Int
-        get() = if (Util.SDK_INT >= 28) audioManager.getStreamMinVolume(streamType) else 0
+        get() = if (Build.VERSION.SDK_INT >= 28) audioManager.getStreamMinVolume(streamType) else 0
 
     /**
      * Gets the maximum volume for the current audio stream. It can be changed if [ ][.setStreamType] is called.
@@ -138,16 +138,11 @@ internal class StreamVolumeManager(context: Context, eventHandler: Handler, list
 
     /** Sets the mute state of the current audio stream.  */
     fun setMuted(muted: Boolean) {
-        if (Util.SDK_INT >= 23) {
-            audioManager.adjustStreamVolume(
-                streamType,
-                if (muted) AudioManager.ADJUST_MUTE else AudioManager.ADJUST_UNMUTE,
-                VOLUME_FLAGS
-            )
-        } else {
-            @Suppress("Deprecation")
-            audioManager.setStreamMute(streamType, muted)
-        }
+        audioManager.adjustStreamVolume(
+            streamType,
+            if (muted) AudioManager.ADJUST_MUTE else AudioManager.ADJUST_UNMUTE,
+            VOLUME_FLAGS
+        )
         updateVolumeAndNotifyIfChanged()
     }
 
@@ -210,11 +205,7 @@ internal class StreamVolumeManager(context: Context, eventHandler: Handler, list
             audioManager: AudioManager,
             streamType: @C.StreamType Int,
         ): Boolean {
-            return if (Util.SDK_INT >= 23) {
-                audioManager.isStreamMute(streamType)
-            } else {
-                getVolumeFromManager(audioManager, streamType) == 0
-            }
+            return audioManager.isStreamMute(streamType)
         }
     }
 }

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
@@ -127,7 +127,7 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
             .onEach { playbackParameters ->
                 notifyListenersPlaybackParametersChanged(lastPlaybackParameters, playbackParameters)
                 lastPlaybackParameters = playbackParameters
-            }
+            }.launchIn(coroutineScope)
     }
 
     private var listeners: ListenerSet<Listener> =
@@ -347,11 +347,6 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
         return previousMediaItemIndex != INDEX_UNSET
     }
 
-    @Deprecated("Deprecated in Java", ReplaceWith("TODO(\"Not yet implemented\")"))
-    override fun seekToPreviousWindow() {
-        seekToPreviousMediaItem()
-    }
-
     override fun seekToPreviousMediaItem() {
         val previousMediaItemIndex = previousMediaItemIndex
         if (previousMediaItemIndex != INDEX_UNSET) {
@@ -380,28 +375,8 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
         }
     }
 
-    @Deprecated("Deprecated in Java", ReplaceWith("hasNextMediaItem()"))
-    override fun hasNext(): Boolean {
-        return hasNextMediaItem()
-    }
-
-    @Deprecated("Deprecated in Java", ReplaceWith("hasNextMediaItem()"))
-    override fun hasNextWindow(): Boolean {
-        return hasNextMediaItem()
-    }
-
     override fun hasNextMediaItem(): Boolean {
         return nextMediaItemIndex != INDEX_UNSET
-    }
-
-    @Deprecated("Deprecated in Java", ReplaceWith("seekToNextMediaItem()"))
-    override fun next() {
-        seekToNextMediaItem()
-    }
-
-    @Deprecated("Deprecated in Java", ReplaceWith("seekToNextMediaItem()"))
-    override fun seekToNextWindow() {
-        seekToNextMediaItem()
     }
 
     override fun seekToNextMediaItem() {

--- a/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/gestures/Fling2DBehavior.kt
+++ b/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/gestures/Fling2DBehavior.kt
@@ -73,7 +73,7 @@ internal class NullFling2DBehavior : Fling2DBehavior {
     }
 }
 
-public fun FlingBehavior.toFling2DBehavior(orientation: Orientation) =
+public fun FlingBehavior.toFling2DBehavior(orientation: Orientation): Fling2DBehavior =
     object : Fling2DBehavior {
         override suspend fun Scroll2DScope.performFling(
             initialVelocity: Velocity,

--- a/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/util/ComposeTypes.kt
+++ b/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/util/ComposeTypes.kt
@@ -23,7 +23,7 @@ public fun ReadingProgression.toLayoutDirection(): LayoutDirection =
         ReadingProgression.RTL -> LayoutDirection.Rtl
     }
 
-public fun Axis.toOrientation() = when (this) {
+public fun Axis.toOrientation(): Orientation = when (this) {
     Axis.HORIZONTAL -> Orientation.Horizontal
     Axis.VERTICAL -> Orientation.Vertical
 }

--- a/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/util/Geometry.kt
+++ b/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/util/Geometry.kt
@@ -9,7 +9,7 @@ package org.readium.navigator.web.internals.util
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 
-public fun DpRect.shift(offset: DpOffset) = DpRect(
+public fun DpRect.shift(offset: DpOffset): DpRect = DpRect(
     left = left + offset.x,
     right = right + offset.x,
     top = top + offset.y,

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/MemoryObserver.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/MemoryObserver.kt
@@ -54,6 +54,7 @@ public interface MemoryObserver {
             object : ComponentCallbacks2 {
                 override fun onConfigurationChanged(config: Configuration) {}
 
+                @Suppress("OVERRIDE_DEPRECATION")
                 @Deprecated("Deprecated in Java")
                 override fun onLowMemory() {}
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/zip/compress/archivers/zip/ExtraFieldUtils.java
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/zip/compress/archivers/zip/ExtraFieldUtils.java
@@ -33,7 +33,7 @@ import java.util.zip.ZipException;
 
 /**
  * ZipExtraField related methods
- * @NotThreadSafe because the HashMap is not synch.
+ * @NotThreadSafe because the HashMap is not sync.
  */
 // CheckStyle:HideUtilityClassConstructorCheck OFF (bc)
 public class ExtraFieldUtils {

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/resource/DirectoryContainerTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/resource/DirectoryContainerTest.kt
@@ -9,7 +9,6 @@
 
 package org.readium.r2.shared.util.resource
 
-import android.webkit.MimeTypeMap
 import java.nio.charset.StandardCharsets
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -26,7 +25,6 @@ import org.readium.r2.shared.util.data.Container
 import org.readium.r2.shared.util.file.DirectoryContainer
 import org.readium.r2.shared.util.toAbsoluteUrl
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows
 
 @RunWith(RobolectricTestRunner::class)
 class DirectoryContainerTest {
@@ -114,11 +112,6 @@ class DirectoryContainerTest {
     fun `Computing entries works well`() {
         runBlocking {
             // FIXME: Test media types
-            Shadows.shadowOf(MimeTypeMap.getSingleton()).apply {
-                addExtensionMimeTypeMapping("txt", "text/plain")
-                addExtensionMimeTypeMapping("mp3", "audio/mpeg")
-            }
-
             val entries = sut().entries
             assertThat(entries).contains(
                 Url("subdirectory/hello.mp3")!!,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,21 +46,21 @@ include(":readium:navigators:common")
 project(":readium:navigators:common")
     .name = "readium-navigator-common"
 
-// include(":readium:navigators:web:common")
-// project(":readium:navigators:web:common")
-//     .name = "readium-navigator-web-common"
-//
-// include(":readium:navigators:web:internals")
-// project(":readium:navigators:web:internals")
-//     .name = "readium-navigator-web-internals"
-//
-// include(":readium:navigators:web:reflowable")
-// project(":readium:navigators:web:reflowable")
-//     .name = "readium-navigator-web-reflowable"
-//
-// include(":readium:navigators:web:fixedlayout")
-// project(":readium:navigators:web:fixedlayout")
-//     .name = "readium-navigator-web-fixedlayout"
+include(":readium:navigators:web:common")
+project(":readium:navigators:web:common")
+    .name = "readium-navigator-web-common"
+
+include(":readium:navigators:web:internals")
+project(":readium:navigators:web:internals")
+    .name = "readium-navigator-web-internals"
+
+include(":readium:navigators:web:reflowable")
+project(":readium:navigators:web:reflowable")
+    .name = "readium-navigator-web-reflowable"
+
+include(":readium:navigators:web:fixedlayout")
+project(":readium:navigators:web:fixedlayout")
+    .name = "readium-navigator-web-fixedlayout"
 
 include(":readium:navigators:media:common")
 project(":readium:navigators:media:common")
@@ -91,4 +91,4 @@ project(":readium:streamer")
     .name = "readium-streamer"
 
 include("test-app")
-// include(":demos:navigator")
+include(":demos:navigator")

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 /*
  * Copyright 2021 Readium Foundation. All rights reserved.
  * Use of this source code is governed by the BSD-style license
@@ -30,14 +32,11 @@ android {
         ndk.abiFilters.add("x86_64")
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
-    }
+
     buildFeatures {
         viewBinding = true
         compose = true
@@ -61,6 +60,13 @@ android {
         }
     }
     namespace = "org.readium.r2.testapp"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Update dependencies including AGP and bump JVM target  to 11 (1.8 is deprecated).