### PR TITLE
Prevent multiple OutlineFragment instances on repeated menu clicks.

### DIFF
--- a/test-app/src/main/java/org/readium/r2/testapp/reader/ReaderActivity.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/reader/ReaderActivity.kt
@@ -153,7 +153,7 @@ open class ReaderActivity : AppCompatActivity() {
 
     private fun showOutlineFragment() {
         val outlineFragment = supportFragmentManager.findFragmentByTag(OUTLINE_FRAGMENT_TAG)
-        if(outlineFragment == null) {
+        if (outlineFragment == null) {
             supportFragmentManager.commit {
                 add(
                     R.id.activity_container,

--- a/test-app/src/main/java/org/readium/r2/testapp/reader/ReaderActivity.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/reader/ReaderActivity.kt
@@ -152,15 +152,18 @@ open class ReaderActivity : AppCompatActivity() {
     }
 
     private fun showOutlineFragment() {
-        supportFragmentManager.commit {
-            add(
-                R.id.activity_container,
-                OutlineFragment::class.java,
-                Bundle(),
-                OUTLINE_FRAGMENT_TAG
-            )
-            hide(readerFragment)
-            addToBackStack(null)
+        val outlineFragment = supportFragmentManager.findFragmentByTag(OUTLINE_FRAGMENT_TAG)
+        if(outlineFragment == null) {
+            supportFragmentManager.commit {
+                add(
+                    R.id.activity_container,
+                    OutlineFragment::class.java,
+                    Bundle(),
+                    OUTLINE_FRAGMENT_TAG
+                )
+                hide(readerFragment)
+                addToBackStack(null)
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes the issue where multiple OutlineFragment instances are added when the menu item is clicked repeatedly in quick succession in the ReaderActivity.

<img width="341" height="692" alt="Screenshot 2025-10-17 at 3 38 56 PM" src="https://github.com/user-attachments/assets/f298e99e-3dcd-4288-9ff0-e74bffffd4f8" />

Fix: Before adding OutlineFragment, we now check if it already exists in the FragmentManager using findFragmentByTag.

Tested by repeatedly tapping the ≡ menu icon multiple times very quickly and confirmed that only a single instance of OutlineFragment is ever created.

