### PR TITLE
Allow custom LCP device identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ captures/
 .idea/jarRepositories.xml
 .idea/misc.xml
 .idea/migrations.xml
+.idea/markdown.xml
 # Android Studio 3 in .gitignore file.
 .idea/caches
 .idea/modules.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+#### LCP
+
+* Added a constructor parameter to pass a custom device id.
+
+### Changed
+
+#### LCP
+
+* Set device id only once after generating.
 
 ## [3.1.2]
 

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -135,8 +135,9 @@ public interface LcpService {
          * @param deviceName Device name used when registering a license to an LSD server.
          * If not provided, the device name will be generated from the device's manufacturer and
          * model.
-         * @param deviceId Device ID used when registering a liceense to an LSD server.
-         * If not provided, the device id will be generated as a random UUID.
+         * @param deviceId Device ID used when registering a license to an LSD server.
+         * If not provided, the device ID will be generated as a random UUID and persisted for
+         * future sessions.
          */
         public operator fun invoke(
             context: Context,

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -135,11 +135,14 @@ public interface LcpService {
          * @param deviceName Device name used when registering a license to an LSD server.
          * If not provided, the device name will be generated from the device's manufacturer and
          * model.
+         * @param deviceId Device ID used when registering a liceense to an LSD server.
+         * If not provided, the device id will be generated as a random UUID.
          */
         public operator fun invoke(
             context: Context,
             assetRetriever: AssetRetriever,
             deviceName: String? = null,
+            deviceId: String? = null,
         ): LcpService? {
             if (!LcpClient.isAvailable()) {
                 return null
@@ -152,6 +155,7 @@ public interface LcpService {
             val network = NetworkService()
             val device = DeviceService(
                 deviceName = deviceName,
+                deviceId = deviceId,
                 repository = deviceRepository,
                 network = network,
                 context = context

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
@@ -12,6 +12,7 @@ package org.readium.r2.lcp.service
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
+import androidx.core.content.edit
 import java.io.Serializable
 import java.util.UUID
 import org.readium.r2.lcp.license.model.LicenseDocument
@@ -19,22 +20,21 @@ import org.readium.r2.lcp.license.model.components.Link
 
 internal class DeviceService(
     deviceName: String?,
+    deviceId: String?,
     private val repository: DeviceRepository,
     private val network: NetworkService,
     val context: Context,
 ) : Serializable {
 
-    private val preferences: SharedPreferences = context.getSharedPreferences(
-        "org.readium.r2.settings",
-        Context.MODE_PRIVATE
-    )
+    private val preferences: SharedPreferences by lazy {
+        context.getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
+    }
 
-    val id: String
-        get() {
-            val deviceId = preferences.getString("lcp_device_id", UUID.randomUUID().toString())!!
-            preferences.edit().putString("lcp_device_id", deviceId).apply()
-            return deviceId
-        }
+    val id: String = deviceId ?: run {
+        val deviceId = preferences.getString("lcp_device_id", UUID.randomUUID().toString())!!
+        preferences.edit { putString("lcp_device_id", deviceId) }
+        deviceId
+    }
 
     val name: String =
         deviceName ?: "${Build.MANUFACTURER} ${Build.MODEL}"

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
@@ -10,10 +10,8 @@
 package org.readium.r2.lcp.service
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.os.Build
 import androidx.core.content.edit
-import java.io.Serializable
 import java.util.UUID
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.components.Link
@@ -24,16 +22,21 @@ internal class DeviceService(
     private val repository: DeviceRepository,
     private val network: NetworkService,
     val context: Context,
-) : Serializable {
+) {
 
-    private val preferences: SharedPreferences by lazy {
-        context.getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
-    }
+    val id: String = deviceId ?: generatedId
 
-    val id: String = deviceId ?: run {
-        val deviceId = preferences.getString("lcp_device_id", UUID.randomUUID().toString())!!
-        preferences.edit { putString("lcp_device_id", deviceId) }
-        deviceId
+    private val generatedId: String get() {
+        val key = "lcp_device_id"
+
+        val preferences = context.getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
+
+        preferences.getString(key, null)
+            ?.let { return it }
+
+        val id = UUID.randomUUID().toString()
+        preferences.edit { putString(key, id) }
+        return id
     }
 
     val name: String =


### PR DESCRIPTION
Also make sure that we set generated device id only once after `DeviceService` has been initialized