### PR TITLE
Add experimental EPUB decoration positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+#### Navigator
+
+* New experimental positioning of EPUB decorations that places highlights behind text to improve legibility with opaque decorations (contributed by [@ddfreiling](https://github.com/readium/kotlin-toolkit/pull/721)).
+    * To opt-in, initialize the `EpubNavigatorFragment.Configuration` object with `decorationTemplates = HtmlDecorationTemplates.defaultTemplates(alpha = 1.0, experimentalPositioning = true)`.
+
 
 ## [3.1.2]
 

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -8,6 +8,7 @@
 
 package org.readium.r2.navigator.epub
 
+import android.graphics.Color
 import android.graphics.PointF
 import android.graphics.RectF
 import android.os.Bundle
@@ -20,6 +21,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
+import androidx.annotation.ColorInt
 import androidx.collection.forEach
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.BundleCompat
@@ -214,14 +216,17 @@ public class EpubNavigatorFragment internal constructor(
         public constructor(
             servedAssets: List<String> = emptyList(),
             readiumCssRsProperties: RsProperties = RsProperties(),
-            decorationTemplates: HtmlDecorationTemplates = HtmlDecorationTemplates.defaultTemplates(),
+            decorationTemplates: HtmlDecorationTemplates? = null,
             disablePageTurnsWhileScrolling: Boolean = false,
             selectionActionModeCallback: ActionMode.Callback? = null,
             shouldApplyInsetsPadding: Boolean? = true,
+            experimentalDecorationPositioning: Boolean? = false,
         ) : this(
             servedAssets = servedAssets,
             readiumCssRsProperties = readiumCssRsProperties,
-            decorationTemplates = decorationTemplates,
+            decorationTemplates = decorationTemplates ?: HtmlDecorationTemplates.defaultTemplates(
+                experimentalPositioning = experimentalDecorationPositioning == true
+            ),
             disablePageTurnsWhileScrolling = disablePageTurnsWhileScrolling,
             selectionActionModeCallback = selectionActionModeCallback,
             shouldApplyInsetsPadding = shouldApplyInsetsPadding,
@@ -258,6 +263,27 @@ public class EpubNavigatorFragment internal constructor(
                 builderAction = builderAction
             )
         }
+
+        /**
+         * Update default decorations, to change styling and positioning.
+         */
+        public fun updateDefaultDecorations(
+            @ColorInt defaultTint: Int = Color.YELLOW,
+            lineWeight: Int = 2,
+            cornerRadius: Int = 3,
+            alpha: Double = 0.3,
+            experimentalPositioning: Boolean = false,
+        ) {
+                val updatedDefaultTemplates =
+                    HtmlDecorationTemplates.defaultTemplates(
+                        defaultTint,
+                        lineWeight,
+                        cornerRadius,
+                        alpha,
+                        experimentalPositioning,
+                    )
+                decorationTemplates = decorationTemplates.copyWith(updatedDefaultTemplates)
+            }
 
         public companion object {
             public operator fun invoke(builder: Configuration.() -> Unit): Configuration =

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -274,16 +274,16 @@ public class EpubNavigatorFragment internal constructor(
             alpha: Double = 0.3,
             experimentalPositioning: Boolean = false,
         ) {
-                val updatedDefaultTemplates =
-                    HtmlDecorationTemplates.defaultTemplates(
-                        defaultTint,
-                        lineWeight,
-                        cornerRadius,
-                        alpha,
-                        experimentalPositioning,
-                    )
-                decorationTemplates = decorationTemplates.copyWith(updatedDefaultTemplates)
-            }
+            val updatedDefaultTemplates =
+                HtmlDecorationTemplates.defaultTemplates(
+                    defaultTint,
+                    lineWeight,
+                    cornerRadius,
+                    alpha,
+                    experimentalPositioning,
+                )
+            decorationTemplates = decorationTemplates.copyWith(updatedDefaultTemplates)
+        }
 
         public companion object {
             public operator fun invoke(builder: Configuration.() -> Unit): Configuration =

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -8,7 +8,6 @@
 
 package org.readium.r2.navigator.epub
 
-import android.graphics.Color
 import android.graphics.PointF
 import android.graphics.RectF
 import android.os.Bundle
@@ -21,7 +20,6 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import androidx.annotation.ColorInt
 import androidx.collection.forEach
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.BundleCompat
@@ -216,17 +214,14 @@ public class EpubNavigatorFragment internal constructor(
         public constructor(
             servedAssets: List<String> = emptyList(),
             readiumCssRsProperties: RsProperties = RsProperties(),
-            decorationTemplates: HtmlDecorationTemplates? = null,
+            decorationTemplates: HtmlDecorationTemplates = HtmlDecorationTemplates.defaultTemplates(),
             disablePageTurnsWhileScrolling: Boolean = false,
             selectionActionModeCallback: ActionMode.Callback? = null,
             shouldApplyInsetsPadding: Boolean? = true,
-            experimentalDecorationPositioning: Boolean? = false,
         ) : this(
             servedAssets = servedAssets,
             readiumCssRsProperties = readiumCssRsProperties,
-            decorationTemplates = decorationTemplates ?: HtmlDecorationTemplates.defaultTemplates(
-                experimentalPositioning = experimentalDecorationPositioning == true
-            ),
+            decorationTemplates = decorationTemplates,
             disablePageTurnsWhileScrolling = disablePageTurnsWhileScrolling,
             selectionActionModeCallback = selectionActionModeCallback,
             shouldApplyInsetsPadding = shouldApplyInsetsPadding,
@@ -262,27 +257,6 @@ public class EpubNavigatorFragment internal constructor(
                 alternates = alternates.map { it.name },
                 builderAction = builderAction
             )
-        }
-
-        /**
-         * Update default decorations, to change styling and positioning.
-         */
-        public fun updateDefaultDecorations(
-            @ColorInt defaultTint: Int = Color.YELLOW,
-            lineWeight: Int = 2,
-            cornerRadius: Int = 3,
-            alpha: Double = 0.3,
-            experimentalPositioning: Boolean = false,
-        ) {
-            val updatedDefaultTemplates =
-                HtmlDecorationTemplates.defaultTemplates(
-                    defaultTint,
-                    lineWeight,
-                    cornerRadius,
-                    alpha,
-                    experimentalPositioning,
-                )
-            decorationTemplates = decorationTemplates.copyWith(updatedDefaultTemplates)
         }
 
         public companion object {

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/html/HtmlDecorationTemplate.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/html/HtmlDecorationTemplate.kt
@@ -94,13 +94,15 @@ public data class HtmlDecorationTemplate(
             lineWeight: Int,
             cornerRadius: Int,
             alpha: Double,
+            experimentalPositioning: Boolean = false,
         ): HtmlDecorationTemplate =
             createTemplate(
                 asHighlight = true,
                 defaultTint = defaultTint,
                 lineWeight = lineWeight,
                 cornerRadius = cornerRadius,
-                alpha = alpha
+                alpha = alpha,
+                experimentalPositioning = experimentalPositioning,
             )
 
         /** Creates a new decoration template for the underline style. */
@@ -109,13 +111,15 @@ public data class HtmlDecorationTemplate(
             lineWeight: Int,
             cornerRadius: Int,
             alpha: Double,
+            experimentalPositioning: Boolean = false,
         ): HtmlDecorationTemplate =
             createTemplate(
                 asHighlight = false,
                 defaultTint = defaultTint,
                 lineWeight = lineWeight,
                 cornerRadius = cornerRadius,
-                alpha = alpha
+                alpha = alpha,
+                experimentalPositioning = experimentalPositioning,
             )
 
         /**
@@ -128,6 +132,7 @@ public data class HtmlDecorationTemplate(
             lineWeight: Int,
             cornerRadius: Int,
             alpha: Double,
+            experimentalPositioning: Boolean = false,
         ): HtmlDecorationTemplate {
             val className = createUniqueClassName(if (asHighlight) "highlight" else "underline")
             val padding = Padding(left = 1, right = 1)
@@ -140,6 +145,9 @@ public data class HtmlDecorationTemplate(
                     val css = buildString {
                         if (asHighlight || isActive) {
                             append("background-color: ${tint.toCss(alpha = alpha)} !important;")
+                        }
+                        if (experimentalPositioning) {
+                            append("--decoration-z-index: -1;")
                         }
                         if (!asHighlight || isActive) {
                             append("--underline-color: ${tint.toCss()};")
@@ -154,6 +162,7 @@ public data class HtmlDecorationTemplate(
                 border-radius: ${cornerRadius}px;
                 box-sizing: border-box;
                 border: 0 solid var(--underline-color);
+                z-index: var(--decoration-z-index);
             }
             
             /* Horizontal (default) */
@@ -201,6 +210,13 @@ public class HtmlDecorationTemplates private constructor(
 
     public fun copy(): HtmlDecorationTemplates = HtmlDecorationTemplates(styles.toMutableMap())
 
+    public fun copyWith(other: HtmlDecorationTemplates): HtmlDecorationTemplates =
+        copy().apply {
+            other.styles.forEach { (key, value) ->
+                styles[key] = value
+            }
+        }
+
     public companion object {
         public operator fun invoke(build: HtmlDecorationTemplates.() -> Unit): HtmlDecorationTemplates =
             HtmlDecorationTemplates().apply(build)
@@ -213,6 +229,7 @@ public class HtmlDecorationTemplates private constructor(
             lineWeight: Int = 2,
             cornerRadius: Int = 3,
             alpha: Double = 0.3,
+            experimentalPositioning: Boolean = false,
         ): HtmlDecorationTemplates = HtmlDecorationTemplates {
             set(
                 Style.Highlight::class,
@@ -220,7 +237,8 @@ public class HtmlDecorationTemplates private constructor(
                     defaultTint = defaultTint,
                     lineWeight = lineWeight,
                     cornerRadius = cornerRadius,
-                    alpha = alpha
+                    alpha = alpha,
+                    experimentalPositioning = experimentalPositioning,
                 )
             )
             set(
@@ -229,7 +247,8 @@ public class HtmlDecorationTemplates private constructor(
                     defaultTint = defaultTint,
                     lineWeight = lineWeight,
                     cornerRadius = cornerRadius,
-                    alpha = alpha
+                    alpha = alpha,
+                    experimentalPositioning = experimentalPositioning,
                 )
             )
         }

--- a/readium/navigator/src/main/java/org/readium/r2/navigator/html/HtmlDecorationTemplate.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/html/HtmlDecorationTemplate.kt
@@ -210,13 +210,6 @@ public class HtmlDecorationTemplates private constructor(
 
     public fun copy(): HtmlDecorationTemplates = HtmlDecorationTemplates(styles.toMutableMap())
 
-    public fun copyWith(other: HtmlDecorationTemplates): HtmlDecorationTemplates =
-        copy().apply {
-            other.styles.forEach { (key, value) ->
-                styles[key] = value
-            }
-        }
-
     public companion object {
         public operator fun invoke(build: HtmlDecorationTemplates.() -> Unit): HtmlDecorationTemplates =
             HtmlDecorationTemplates().apply(build)

--- a/test-app/src/main/java/org/readium/r2/testapp/reader/EpubReaderFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/reader/EpubReaderFragment.kt
@@ -29,6 +29,7 @@ import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.epub.*
 import org.readium.r2.navigator.epub.css.FontStyle
 import org.readium.r2.navigator.html.HtmlDecorationTemplate
+import org.readium.r2.navigator.html.HtmlDecorationTemplates
 import org.readium.r2.navigator.html.toCss
 import org.readium.r2.navigator.preferences.FontFamily
 import org.readium.r2.shared.ExperimentalReadiumApi
@@ -83,12 +84,16 @@ class EpubReaderFragment : VisualReaderFragment() {
                         "annotation-icon.svg"
                     )
 
+                    // Enable experimental decorations positioning that places highlights behind
+                    // text to improve legibility with opaque decorations.
+                    decorationTemplates = HtmlDecorationTemplates.defaultTemplates(
+                        alpha = 1.0,
+                        experimentalPositioning = true
+                    )
+
                     // Register the HTML templates for our custom decoration styles.
                     decorationTemplates[DecorationStyleAnnotationMark::class] = annotationMarkTemplate()
                     decorationTemplates[DecorationStylePageNumber::class] = pageNumberTemplate()
-
-                    // Update default decorations to be opaque and use experimental positioning.
-                    updateDefaultDecorations(experimentalPositioning = true, alpha = 1.0)
 
                     // Declare a custom font family for reflowable EPUBs.
                     addFontFamilyDeclaration(FontFamily.LITERATA) {

--- a/test-app/src/main/java/org/readium/r2/testapp/reader/EpubReaderFragment.kt
+++ b/test-app/src/main/java/org/readium/r2/testapp/reader/EpubReaderFragment.kt
@@ -87,6 +87,9 @@ class EpubReaderFragment : VisualReaderFragment() {
                     decorationTemplates[DecorationStyleAnnotationMark::class] = annotationMarkTemplate()
                     decorationTemplates[DecorationStylePageNumber::class] = pageNumberTemplate()
 
+                    // Update default decorations to be opaque and use experimental positioning.
+                    updateDefaultDecorations(experimentalPositioning = true, alpha = 1.0)
+
                     // Declare a custom font family for reflowable EPUBs.
                     addFontFamilyDeclaration(FontFamily.LITERATA) {
                         addFontFace {


### PR DESCRIPTION
Adds an option for EpubNavigator to position default decorations between text and background, allowing for opaque highlight colors.

See swift-toolkit equivalent PR:
https://github.com/readium/swift-toolkit/pull/665

Without experimental positioning:
(notice that highlight affects text color and gives a "blurry" feel.
![exp_without_1](https://github.com/user-attachments/assets/01acdb48-9650-49f2-8de6-673672e3f422)
![exp_without_2](https://github.com/user-attachments/assets/9a1f4fbc-818b-418b-a6ec-778e20009d2f)

With experimental positioning:
![exp_with_1](https://github.com/user-attachments/assets/c1a5ffda-fe5a-438d-8353-eaf8975feae3)
![exp_with_2](https://github.com/user-attachments/assets/04979ddb-e585-4caa-9277-cc57f7debc0e)
(here highlight is also opaque with alpha = 1.0)
