### PR TITLE
Add a new constructor to EpubParser to enable the use of a custom PositionsService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Added
 
+#### Streamer
+
+* Added a constructor to `EpubParser` to enable the use of a custom `PositionsService`.
+
 #### Navigator
 
 * New experimental positioning of EPUB decorations that places highlights behind text to improve legibility with opaque decorations (contributed by [@ddfreiling](https://github.com/readium/kotlin-toolkit/pull/721)).

--- a/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubParser.kt
+++ b/readium/streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubParser.kt
@@ -14,6 +14,7 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.encryption.Encryption
 import org.readium.r2.shared.publication.epub.EpubEncryptionParser
+import org.readium.r2.shared.publication.services.PositionsService
 import org.readium.r2.shared.publication.services.content.DefaultContentService
 import org.readium.r2.shared.publication.services.content.iterators.HtmlResourceContentIterator
 import org.readium.r2.shared.publication.services.search.StringSearchService
@@ -43,13 +44,24 @@ import org.readium.r2.streamer.parser.PublicationParser
 /**
  * Parses a Publication from an EPUB publication.
  *
- * @param reflowablePositionsStrategy Strategy used to calculate the number of positions in a
- *        reflowable resource.
+ * @constructor Creates an [EpubParser] using a custom [PositionsService] factory.
+ * @param positionsServiceFactory Factory to create the [PositionsService] that will be used
+ *  by the publication.
  */
 @OptIn(ExperimentalReadiumApi::class)
 public class EpubParser(
-    private val reflowablePositionsStrategy: EpubPositionsService.ReflowableStrategy = EpubPositionsService.ReflowableStrategy.recommended,
+    private val positionsServiceFactory: (Publication.Service.Context) -> PositionsService,
 ) : PublicationParser {
+
+    /**
+     * Creates an [EpubParser] using the default [PositionsService] factory.
+     *
+     * @param reflowablePositionsStrategy Strategy used to calculate the number of positions in a
+     *        reflowable resource.
+     */
+    public constructor(
+        reflowablePositionsStrategy: EpubPositionsService.ReflowableStrategy = EpubPositionsService.ReflowableStrategy.recommended,
+    ) : this(EpubPositionsService.createFactory(reflowablePositionsStrategy))
 
     override suspend fun parse(
         asset: Asset,
@@ -103,7 +115,7 @@ public class EpubParser(
             manifest = manifest,
             container = container,
             servicesBuilder = Publication.ServicesBuilder(
-                positions = EpubPositionsService.createFactory(reflowablePositionsStrategy),
+                positions = positionsServiceFactory,
                 search = StringSearchService.createDefaultFactory(),
                 content = DefaultContentService.createFactory(
                     resourceContentIteratorFactories = listOf(


### PR DESCRIPTION
`EpubPositionsService.ReflowableStrategy` turns out to be too opinionated in some cases: every resource gets a page number separately from the others. It's not suitable if you want to allocate resources a share of a predetermined number of pages  in proportion to their length.

As nobody had complained until now, I guess this is not a common use case to support in the `EpubPositionsService`.