### PR TITLE
Fix typo in `describedMath` a11y feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to this project will be documented in this file. Take a look
     * You must ensure the identifier is unique and stable for the device (persist and reuse across app launches).
     * Recommended: generate an app-scoped UUID and store it securely. Avoid hardware or advertising identifiers.
 
+### Fixed
+
+#### Shared
+
+* Fixed a typo in the accessibility metadata (`describeMath` should be `describedMath`).
+
 
 ## [3.1.2]
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Accessibility.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Accessibility.kt
@@ -447,7 +447,7 @@ public data class Accessibility(
              * Textual descriptions of math equations are included, whether in the alt attribute
              * for image-based equations,
              */
-            public val DESCRIBED_MATH: Feature = Feature("describeMath")
+            public val DESCRIBED_MATH: Feature = Feature("describedMath")
 
             /**
              * Descriptions are provided for image-based visual content and/or complex structures


### PR DESCRIPTION
### Fixed

#### Shared

* Fixed a typo in the accessibility metadata (`describeMath` should be `describedMath`).

Source: https://www.w3.org/community/reports/a11y-discov-vocab/CG-FINAL-vocabulary-20241209/#describedMath