### PR TITLE
GitHub Actions CI Build Improvements

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,16 +15,16 @@ jobs:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'adopt'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
         with:
-          #Read cache in PRs, write to cache after merge to main or develop
+          # Read cache in PRs, write to cache after merge to main or develop
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
       - name: Build and Test
         run: ./gradlew assembleDebug testDebugUnitTest lintDebug
@@ -35,9 +35,9 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -52,14 +52,14 @@ jobs:
       scripts: ${{ 'readium/navigator/src/main/assets/_scripts' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           package_json_file: readium/navigator/src/main/assets/_scripts/package.json
           run_install: false
       - name: Setup cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -82,14 +82,14 @@ jobs:
       scripts: ${{ 'readium/navigators/web/internals/scripts' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           package_json_file: readium/navigators/web/internals/scripts/package.json
           run_install: false
       - name: Setup cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,10 +19,15 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          #Read cache in PRs, write to cache after merge to main or develop
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
       - name: Build
-        run: ./gradlew clean build -x test -x ktlintMainSourceSetCheck
+        run: ./gradlew build -x test -x ktlintMainSourceSetCheck --configuration-cache
       - name: Test
-        run: ./gradlew test --continue
+        run: ./gradlew test --continue --configuration-cache
 
   lint-kt:
     name: Lint Kotlin
@@ -67,8 +72,8 @@ jobs:
         run: pnpm --dir "$scripts" run checkformat
       - name: Check if bundled scripts are up-to-date
         run: |
-            make scripts-legacy
-            git diff --exit-code --name-only src/main/assets/readium/scripts/*.js
+          make scripts-legacy
+          git diff --exit-code --name-only src/main/assets/readium/scripts/*.js
   lint-new-ts:
     name: Lint TypeScript
     runs-on: macos-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,8 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,10 +26,8 @@ jobs:
         with:
           #Read cache in PRs, write to cache after merge to main or develop
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
-      - name: Build
-        run: ./gradlew build -x test -x ktlintMainSourceSetCheck --configuration-cache
-      - name: Test
-        run: ./gradlew test --continue --configuration-cache
+      - name: Build and Test
+        run: ./gradlew assembleDebug testDebugUnitTest lintDebug
 
   lint-kt:
     name: Lint Kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+ org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
This PR aims to improve the build times in GitHub Actions, as they are taking 20+ minutes now.

1. Enabled parallel builds of the individual modules.
2. Removed `clean` from the task, as it's not needed.
3. Cache gradle dependencies.
4. Combine build and test steps.
5. Remove building any release variants.