### PR TITLE
Update Gradle, AGP, and other dependencies

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="version" value="2.2.0" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Guides are available to help you make the most of the toolkit.
 
 | Readium   | Android min SDK | Android compile SDK | Kotlin compiler (✻) | Gradle (✻) |
 |-----------|-----------------|---------------------|---------------------|------------|
-| `develop` | 21              | 36                  | 2.1.21              | 8.14.1     |
+| `develop` | 21              | 36                  | 2.3.0               | 9.1.0      |
 | 3.1.0     | 21              | 35                  | 2.1.20              | 8.13       |
 | 3.0.0     | 21              | 34                  | 1.9.24              | 8.6.0      |
 | 2.3.0     | 21              | 33                  | 1.7.10              | 6.9.3      |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,14 @@ subprojects {
     ktlint {
         android.set(true)
     }
+
+    afterEvaluate {
+        if (tasks.findByName("clean") == null) {
+            tasks.register<Delete>("clean") {
+                delete(layout.buildDirectory)
+            }
+        }
+    }
 }
 
 tasks.register("cleanDocs", Delete::class).configure {
@@ -39,4 +47,8 @@ tasks.withType<DokkaTaskPartial>().configureEach {
 
 tasks.named<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaGfmMultiModule").configure {
     outputDirectory.set(file("${projectDir.path}/docs"))
+}
+
+tasks.register<Delete>("clean") {
+    delete(layout.buildDirectory)
 }

--- a/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/readium.library-conventions.gradle.kts
@@ -1,11 +1,9 @@
 import com.vanniktech.maven.publish.SonatypeHost
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     // FIXME: For now, we cannot use the versions catalog in precompiled scripts: https://github.com/gradle/gradle/issues/15383
     id("com.android.library")
     id("com.vanniktech.maven.publish")
-    id("org.jetbrains.kotlin.android")
     kotlin("plugin.parcelize")
 }
 
@@ -39,7 +37,7 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"))
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
 }
@@ -49,7 +47,7 @@ kotlin {
     
     compilerOptions {
         freeCompilerArgs.add("-Xannotation-default-target=param-property")
-        jvmTarget = JvmTarget.JVM_11
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3
         allWarningsAsErrors = true
     }
 }

--- a/demos/navigator/build.gradle.kts
+++ b/demos/navigator/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id("com.android.application")
-    kotlin("android")
     kotlin("plugin.parcelize")
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
@@ -50,9 +47,9 @@ android {
 
     sourceSets {
         getByName("main") {
-            java.srcDirs("src/main/java")
-            res.srcDirs("src/main/res")
-            assets.srcDirs("src/main/assets")
+            java.directories.add("src/main/java")
+            java.directories.add("src/main/res")
+            java.directories.add("src/main/assets")
         }
     }
     namespace = "org.readium.demo.navigator"
@@ -61,7 +58,7 @@ android {
 kotlin {
 
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,14 @@ android.useAndroidX=true
 kotlin.code.style=official
 
 ksp.useKSP2=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=true
+android.usesSdkInManifest.disallowed=true
+android.uniquePackageNames=true
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=true
+android.r8.optimizedResourceShrinking=true
+android.builtInKotlin=true
+android.newDsl=true
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,35 +1,35 @@
 [versions]
 
-kotlin = "2.2.20"
-agp = "8.11.1"
+kotlin = "2.3.0"
+agp = "9.0.0"
 desugar_jdk_libs = "2.1.5"
 gradle-maven-publish-plugin = "0.32.0"
 
-androidx-activity = "1.11.0"
+androidx-activity = "1.12.2"
 androidx-annotation = "1.9.1"
 androidx-appcompat = "1.7.1"
 androidx-browser = "1.9.0"
 androidx-cardview = "1.0.0"
-androidx-compose-animation = "1.9.2"
-androidx-compose-foundation = "1.9.2"
-androidx-compose-material = "1.9.2"
+androidx-compose-animation = "1.10.1"
+androidx-compose-foundation = "1.10.1"
+androidx-compose-material = "1.10.1"
 androidx-compose-material-icons = "1.7.8"
 androidx-compose-material3 = "1.4.0"
-androidx-compose-runtime = "1.9.2"
-androidx-compose-ui = "1.9.2"
+androidx-compose-runtime = "1.10.1"
+androidx-compose-ui = "1.10.1"
 androidx-constraintlayout = "2.2.1"
 androidx-core = "1.17.0"
-androidx-datastore = "1.1.7"
+androidx-datastore = "1.2.0"
 androidx-fragment-ktx = "1.8.9"
 androidx-legacy = "1.0.0"
-androidx-lifecycle = "2.9.4"
-androidx-media3 = "1.8.0"
-androidx-navigation = "2.9.5"
+androidx-lifecycle = "2.10.0"
+androidx-media3 = "1.9.0"
+androidx-navigation = "2.9.6"
 androidx-paging = "3.3.6"
 androidx-recyclerview = "1.4.0"
-androidx-room = "2.8.1"
+androidx-room = "2.8.4"
 androidx-viewpager2 = "1.1.0"
-androidx-webkit = "1.14.0"
+androidx-webkit = "1.15.0"
 
 assertj = "3.27.6"
 
@@ -49,10 +49,7 @@ kotlinx-datetime = "0.7.1"
 kotlinx-serialization-json = "1.8.1"
 kotlinx-collections-immutable = "0.4.0"
 
-
-# Make sure to align with the Kotlin version.
-# See https://github.com/google/ksp/releases
-ksp = "2.2.20-2.0.3"
+ksp = "2.3.4"
 
 ktlint = "12.1.1"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 kotlin {
     compilerOptions {
         // See https://github.com/readium/kotlin-toolkit/pull/525#issuecomment-2300084041
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3
         freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
     }
 }

--- a/readium/navigator/build.gradle.kts
+++ b/readium/navigator/build.gradle.kts
@@ -15,15 +15,14 @@ android {
     buildFeatures {
         viewBinding = true
     }
-
-    kotlinOptions {
-    }
 }
 
 kotlin {
     compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3
         // See https://github.com/readium/kotlin-toolkit/pull/525#issuecomment-2300084041
         freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
+        allWarningsAsErrors = false
     }
 }
 

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsPlayer.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/TtsPlayer.kt
@@ -351,15 +351,17 @@ internal class TtsPlayer<
         }
     }
 
-    private suspend fun nextUtteranceAsync() = mutex.withLock {
-        if (utteranceWindow.nextUtterance == null) {
-            return
-        }
+    private suspend fun nextUtteranceAsync() {
+        mutex.withLock {
+            if (utteranceWindow.nextUtterance == null) {
+                return
+            }
 
-        playbackJob?.cancel()
-        tryLoadNextContext()
-        playbackJob?.join()
-        playIfReadyAndNotPaused()
+            playbackJob?.cancel()
+            tryLoadNextContext()
+            playbackJob?.join()
+            playIfReadyAndNotPaused()
+        }
     }
 
     fun hasPreviousUtterance() =
@@ -371,14 +373,16 @@ internal class TtsPlayer<
         }
     }
 
-    private suspend fun previousUtteranceAsync() = mutex.withLock {
-        if (utteranceWindow.previousUtterance == null) {
-            return
+    private suspend fun previousUtteranceAsync() {
+        mutex.withLock {
+            if (utteranceWindow.previousUtterance == null) {
+                return
+            }
+            playbackJob?.cancel()
+            tryLoadPreviousContext()
+            playbackJob?.join()
+            playIfReadyAndNotPaused()
         }
-        playbackJob?.cancel()
-        tryLoadPreviousContext()
-        playbackJob?.join()
-        playIfReadyAndNotPaused()
     }
 
     @Suppress("unused")
@@ -392,17 +396,19 @@ internal class TtsPlayer<
         }
     }
 
-    private suspend fun nextResourceAsync() = mutex.withLock {
-        if (!hasNextUtterance()) {
-            return
-        }
+    private suspend fun nextResourceAsync() {
+        mutex.withLock {
+            if (!hasNextUtterance()) {
+                return
+            }
 
-        playbackJob?.cancel()
-        val currentIndex = utteranceMutable.value.position.resourceIndex
-        contentIterator.seekToResource(currentIndex + 1)
-        resetContext()
-        playbackJob?.join()
-        playIfReadyAndNotPaused()
+            playbackJob?.cancel()
+            val currentIndex = utteranceMutable.value.position.resourceIndex
+            contentIterator.seekToResource(currentIndex + 1)
+            resetContext()
+            playbackJob?.join()
+            playIfReadyAndNotPaused()
+        }
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
@@ -416,16 +422,18 @@ internal class TtsPlayer<
         }
     }
 
-    private suspend fun previousResourceAsync() = mutex.withLock {
-        if (!hasPreviousResource()) {
-            return
+    private suspend fun previousResourceAsync() {
+        mutex.withLock {
+            if (!hasPreviousResource()) {
+                return
+            }
+            playbackJob?.cancel()
+            val currentIndex = utteranceMutable.value.position.resourceIndex
+            contentIterator.seekToResource(currentIndex - 1)
+            resetContext()
+            playbackJob?.join()
+            playIfReadyAndNotPaused()
         }
-        playbackJob?.cancel()
-        val currentIndex = utteranceMutable.value.position.resourceIndex
-        contentIterator.seekToResource(currentIndex - 1)
-        resetContext()
-        playbackJob?.join()
-        playIfReadyAndNotPaused()
     }
 
     private fun playIfReadyAndNotPaused() {

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/AudioFocusManager.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/AudioFocusManager.kt
@@ -231,7 +231,7 @@ internal class AudioFocusManager(
             val willPauseWhenDucked = willPauseWhenDucked()
             audioFocusRequest = builder
                 .setAudioAttributes(
-                    checkNotNull(audioAttributes).audioAttributesV21.audioAttributes
+                    checkNotNull(audioAttributes).platformAudioAttributes
                 )
                 .setWillPauseWhenDucked(willPauseWhenDucked)
                 .setOnAudioFocusChangeListener(focusListener)

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/StreamVolumeManager.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/StreamVolumeManager.kt
@@ -23,8 +23,8 @@ import android.media.AudioManager
 import android.os.Build
 import android.os.Handler
 import androidx.media3.common.C
-import androidx.media3.common.util.Assertions
 import androidx.media3.common.util.Log
+import com.google.common.base.Preconditions
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 /** A manager that wraps [AudioManager] to control/listen audio stream volume.  */
@@ -52,7 +52,7 @@ internal class StreamVolumeManager(context: Context, eventHandler: Handler, list
         applicationContext = context.applicationContext
         this.eventHandler = eventHandler
         this.listener = listener
-        audioManager = Assertions.checkStateNotNull(
+        audioManager = Preconditions.checkNotNull(
             applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         )
         streamType = C.STREAM_TYPE_DEFAULT

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
@@ -652,6 +652,14 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
         return 1.0f
     }
 
+    override fun mute() {
+        
+    }
+
+    override fun unmute() {
+
+    }
+
     override fun clearVideoSurface() {
     }
 

--- a/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/webview/WebViewScrollController.kt
+++ b/readium/navigators/web/internals/src/main/kotlin/org/readium/navigator/web/internals/webview/WebViewScrollController.kt
@@ -169,7 +169,7 @@ private fun RelaxedWebView.scrollToProgression(
 ) {
     when (orientation) {
         Orientation.Vertical -> {
-            scrollTo(scrollX, progression.roundToInt() * maxScrollY.toInt())
+            scrollTo(scrollX, progression.roundToInt() * maxScrollY)
         }
         Orientation.Horizontal -> when (direction) {
             LayoutDirection.Ltr -> {

--- a/readium/opds/src/main/java/org/readium/r2/opds/OPDS1Parser.kt
+++ b/readium/opds/src/main/java/org/readium/r2/opds/OPDS1Parser.kt
@@ -101,11 +101,11 @@ public class OPDS1Parser {
 
             val totalResults = root.getFirst("TotalResults", Namespaces.Search)?.text
             totalResults?.let {
-                feed.metadata.numberOfItems = totalResults.toString().toInt()
+                feed.metadata.numberOfItems = totalResults.toInt()
             }
             val itemsPerPage = root.getFirst("ItemsPerPage", Namespaces.Search)?.text
             itemsPerPage?.let {
-                feed.metadata.itemsPerPage = itemsPerPage.toString().toInt()
+                feed.metadata.itemsPerPage = itemsPerPage.toInt()
             }
 
             // Parse entries

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 /*
  * Copyright 2021 Readium Foundation. All rights reserved.
  * Use of this source code is governed by the BSD-style license
@@ -8,7 +6,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    kotlin("android")
     kotlin("plugin.parcelize")
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
@@ -45,7 +42,7 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"))
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
     packaging {
@@ -54,9 +51,9 @@ android {
 
     sourceSets {
         getByName("main") {
-            java.srcDirs("src/main/java")
-            res.srcDirs("src/main/res")
-            assets.srcDirs("src/main/assets")
+            java.directories.add("src/main/java")
+            java.directories.add("src/main/res")
+            java.directories.add("src/main/assets")
         }
     }
     namespace = "org.readium.r2.testapp"
@@ -64,7 +61,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3
         freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }
@@ -92,6 +89,7 @@ dependencies {
     implementation(libs.androidx.cardview)
 
     implementation(libs.bundles.compose)
+    // Enable this if you need the Compose Layout Inspector
 //    debugImplementation(libs.androidx.compose.ui)
 
     implementation(libs.androidx.constraintlayout)


### PR DESCRIPTION
- Updates Gradle from 8.14.1 to 9.1.0
- Updates the Android Gradle Plugin from 8.11.1 to 9.0.0. In doing this, I migrated it to built-in Kotlin. That means that the`id("org.jetbrains.kotlin.android")` plugin is no longer needed in the build.gradle.kts files. The `compilerOptions.jvmTarget` block is also no longer needed because its value defaults to android.compileOptions.targetCompatibility.
- The AGP update also introduced several new flags available in gradle.properties.
- Updated dependencies of other libraries (note that KSP is no longer tied to the Kotlin version anymore).
- Fixed deprecations and API changes due to the dependencies updates.
- Modified the root build.gradle.kts to register the clean task everywhere it doesn't have one. Even before this update, using Android Studio's `clean` resulted in errors like this: "Cannot locate tasks that match ':demos:clean' as task 'clean' not found in project ':demos'."