### PR TITLE
Update Dokka, fix documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,22 +13,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch tags
         run: git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.11.6
+          python-version: 3.13
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install mkdocs mkdocs-material mike
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'adopt'
@@ -37,10 +37,15 @@ jobs:
         run: echo "READIUM_VERSION=`git describe --tag --match [0-9]* --abbrev=0`" >> $GITHUB_ENV
 
       - name: Run Dokka
-        run: ./gradlew :dokkaGfmMultiModule
+        run: ./gradlew :dokkaGeneratePublicationHtml
 
       - name: Copy README.md into docs to replace Dokka index.md
-        run: cp README.md index.md
+        run: cp README.md docs/index.md
+
+      - name: Copy Dokka output to docs/api
+        run: |
+          mkdir -p docs/api
+          cp -r build/dokka/html/* docs/api/
 
       - name: Run MkDocs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ lint/reports/
 docs/readium
 docs/index.md
 docs/package-list
+docs/api/
 site/
 androidTestResultsUserPreferences.xml
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,6 @@
  * available in the top-level LICENSE file of the project.
  */
 
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-
 plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.ktlint)
@@ -13,7 +11,9 @@ plugins {
 }
 
 subprojects {
-    if (name != "test-app") {
+    val shouldDocument = name != "test-app" && !path.startsWith(":demos")
+
+    if (shouldDocument) {
         apply(plugin = "org.jetbrains.dokka")
     }
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
@@ -24,19 +24,29 @@ subprojects {
 }
 
 tasks.register("cleanDocs", Delete::class).configure {
-    delete("${project.rootDir}/docs/readium", "${project.rootDir}/docs/index.md", "${project.rootDir}/site")
+    delete(
+        "${project.rootDir}/docs/api", "${project.rootDir}/docs/index.md", "${project.rootDir}/site"
+    )
 }
 
-tasks.withType<DokkaTaskPartial>().configureEach {
-    dokkaSourceSets {
-        configureEach {
-            reportUndocumented.set(false)
-            skipEmptyPackages.set(false)
-            skipDeprecated.set(true)
+subprojects {
+    val shouldDocument = name != "test-app" && !path.startsWith(":demos")
+
+    if (shouldDocument) {
+        pluginManager.withPlugin("org.jetbrains.dokka") {
+            configure<org.jetbrains.dokka.gradle.DokkaExtension> {
+                dokkaSourceSets.configureEach {
+                    reportUndocumented.set(false)
+                    skipEmptyPackages.set(false)
+                    skipDeprecated.set(true)
+                }
+            }
         }
     }
 }
 
-tasks.named<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaGfmMultiModule").configure {
-    outputDirectory.set(file("${projectDir.path}/docs"))
+dependencies {
+    subprojects.filter { it.name != "test-app" && !it.path.startsWith(":demos") }.forEach {
+        dokka(project(it.path))
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,9 @@ subprojects {
 
 tasks.register("cleanDocs", Delete::class).configure {
     delete(
-        "${project.rootDir}/docs/api", "${project.rootDir}/docs/index.md", "${project.rootDir}/site"
+        "${project.rootDir}/docs/api",
+        "${project.rootDir}/docs/index.md",
+        "${project.rootDir}/site"
     )
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,15 +11,24 @@ plugins {
 }
 
 subprojects {
-    val shouldDocument = name != "test-app" && !path.startsWith(":demos")
+    val isLibraryModule = name != "test-app" && !path.startsWith(":demos")
 
-    if (shouldDocument) {
-        apply(plugin = "org.jetbrains.dokka")
-    }
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     ktlint {
         android.set(true)
+    }
+
+    if (isLibraryModule) {
+        apply(plugin = "org.jetbrains.dokka")
+
+        extensions.configure<org.jetbrains.dokka.gradle.DokkaExtension> {
+            dokkaSourceSets.configureEach {
+                reportUndocumented.set(false)
+                skipEmptyPackages.set(false)
+                skipDeprecated.set(true)
+            }
+        }
     }
 }
 
@@ -29,22 +38,6 @@ tasks.register("cleanDocs", Delete::class).configure {
         "${project.rootDir}/docs/index.md",
         "${project.rootDir}/site"
     )
-}
-
-subprojects {
-    val shouldDocument = name != "test-app" && !path.startsWith(":demos")
-
-    if (shouldDocument) {
-        pluginManager.withPlugin("org.jetbrains.dokka") {
-            configure<org.jetbrains.dokka.gradle.DokkaExtension> {
-                dokkaSourceSets.configureEach {
-                    reportUndocumented.set(false)
-                    skipEmptyPackages.set(false)
-                    skipDeprecated.set(true)
-                }
-            }
-        }
-    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ androidx-webkit = "1.14.0"
 
 assertj = "3.27.6"
 
-dokka = "1.9.20"
+dokka = "2.1.0"
 
 google-material = "1.13.0"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_name: kotlin-toolkit
 repo_url: https://github.com/readium/kotlin-toolkit
 
 # Copyright (shown at the footer)
-copyright: 'Copyright &copy; 2023 Readium Foundation'
+copyright: 'Copyright &copy; 2026 Readium Foundation'
 
 # Material theme
 theme:
@@ -19,6 +19,9 @@ theme:
   social:
     - type: 'github'
       link: 'https://github.com/readium/kotlin-toolkit'
+  features:
+    - navigation.tabs
+    - navigation.path
 
 # Extensions
 markdown_extensions:
@@ -44,9 +47,10 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Migration Guide: migration-guide.md
+  - API Reference: api/index.html
   - User Guides:
-      - Navigator preferences: guides/navigator-preferences.md
-      - EPUB font families: guides/epub-fonts.md
+      - Navigator preferences: guides/navigator/preferences.md
+      - EPUB font families: guides/navigator/epub-fonts.md
       - PDF support: guides/pdf.md
       - Text-to-speech: guides/tts.md
       - Extracting the content of a publication: guides/content.md
@@ -57,4 +61,3 @@ extra_css:
 extra:
   version:
     provider: mike
-


### PR DESCRIPTION
This PR updates the Dokka plugin and makes changes to the documentation generation. Right now, at least the way it's configured even though it hasn't been run, the Dokka task generates KDocs in markdown format. From there, the workflow uses mkdocs to combine those KDocs with the `docs` directory and generates the HTML.

This PR changes that. Now, Dokka will generate HTML for the KDocs. When mkdocs runs, it puts a link to the kdocs part of the site in the navigation. We lose the ability to switch versions in the header for Dokka's KDocs (the handwritten docs are not affected by this), but I think that's a small price to pay for having cleaner, better looking KDocs.

I also fixed some of the links in mkdocs.yml to point to the new file locations, but otherwise didn't make any changes to the content.