### PR TITLE
Create listeners before init block to avoid initialization issues

### DIFF
--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
@@ -112,6 +112,14 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
     private var deviceInfo: DeviceInfo =
         createDeviceInfo(streamVolumeManager)
 
+    private var listeners: ListenerSet<Listener> =
+        ListenerSet(
+            applicationLooper,
+            Clock.DEFAULT
+        ) { listener: Listener, flags: FlagSet ->
+            listener.onEvents(this, Events(flags))
+        }
+
     init {
         ttsPlayer.playback
             .onEach { playback ->
@@ -129,14 +137,6 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
                 lastPlaybackParameters = playbackParameters
             }.launchIn(coroutineScope)
     }
-
-    private var listeners: ListenerSet<Listener> =
-        ListenerSet(
-            applicationLooper,
-            Clock.DEFAULT
-        ) { listener: Listener, flags: FlagSet ->
-            listener.onEvents(this, Events(flags))
-        }
 
     private val permanentAvailableCommands =
         Commands.Builder()


### PR DESCRIPTION
`listeners` variable should be initialized before `init` block that may use them, because in some cases they are accessed right from `init` call - and are not initialized at this moment, which leads to crashes.