### PR TITLE
Fix crash when JSONObject is backed by immutable Kotlin map

### DIFF
--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
@@ -68,7 +68,7 @@ public data class Locator(
         val otherLocations: @WriteWith<JSONParceler> Map<String, Any> = emptyMap(),
     ) : JSONable, Parcelable {
 
-        override fun toJSON(): JSONObject = JSONObject(otherLocations).apply {
+        override fun toJSON(): JSONObject = JSONObject(HashMap(otherLocations)).apply {
             putIfNotEmpty("fragments", fragments)
             put("progression", progression)
             put("position", position)
@@ -285,7 +285,7 @@ public data class LocatorCollection(
          */
         val title: String? get() = localizedTitle?.string
 
-        override fun toJSON(): JSONObject = JSONObject(otherMetadata).apply {
+        override fun toJSON(): JSONObject = JSONObject(HashMap(otherMetadata)).apply {
             putIfNotEmpty("title", localizedTitle)
             putOpt("numberOfItems", numberOfItems)
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
@@ -69,7 +69,8 @@ public data class Locator(
     ) : JSONable, Parcelable {
 
         // Some versions of org.json's JSONObject(Map) store the reference directly
-        // without copying, so the map must be mutable.
+        // without copying, so the map must be mutable. And even on other versions,
+        // R8 optimizations can make things go like this.
         override fun toJSON(): JSONObject = JSONObject(otherLocations.toMutableMap()).apply {
             putIfNotEmpty("fragments", fragments)
             put("progression", progression)

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Locator.kt
@@ -68,7 +68,9 @@ public data class Locator(
         val otherLocations: @WriteWith<JSONParceler> Map<String, Any> = emptyMap(),
     ) : JSONable, Parcelable {
 
-        override fun toJSON(): JSONObject = JSONObject(HashMap(otherLocations)).apply {
+        // Some versions of org.json's JSONObject(Map) store the reference directly
+        // without copying, so the map must be mutable.
+        override fun toJSON(): JSONObject = JSONObject(otherLocations.toMutableMap()).apply {
             putIfNotEmpty("fragments", fragments)
             put("progression", progression)
             put("position", position)
@@ -285,7 +287,7 @@ public data class LocatorCollection(
          */
         val title: String? get() = localizedTitle?.string
 
-        override fun toJSON(): JSONObject = JSONObject(HashMap(otherMetadata)).apply {
+        override fun toJSON(): JSONObject = JSONObject(otherMetadata.toMutableMap()).apply {
             putIfNotEmpty("title", localizedTitle)
             putOpt("numberOfItems", numberOfItems)
         }

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
@@ -179,7 +179,7 @@ public data class Metadata(
     /**
      * Serializes a [Metadata] to its RWPM JSON representation.
      */
-    override fun toJSON(): JSONObject = JSONObject(otherMetadata).apply {
+    override fun toJSON(): JSONObject = JSONObject(HashMap(otherMetadata)).apply {
         put("identifier", identifier)
         put("@type", type)
         putIfNotEmpty("conformsTo", conformsTo.map { it.uri })

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
@@ -179,7 +179,7 @@ public data class Metadata(
     /**
      * Serializes a [Metadata] to its RWPM JSON representation.
      */
-    override fun toJSON(): JSONObject = JSONObject(HashMap(otherMetadata)).apply {
+    override fun toJSON(): JSONObject = JSONObject(otherMetadata.toMutableMap()).apply {
         put("identifier", identifier)
         put("@type", type)
         putIfNotEmpty("conformsTo", conformsTo.map { it.uri })

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Properties.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Properties.kt
@@ -34,7 +34,7 @@ public data class Properties(
     /**
      * Serializes a [Properties] to its RWPM JSON representation.
      */
-    override fun toJSON(): JSONObject = JSONObject(HashMap(otherProperties))
+    override fun toJSON(): JSONObject = JSONObject(otherProperties.toMutableMap())
 
     /**
      * Makes a copy of this [Properties] after merging in the given additional other [properties].

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Properties.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Properties.kt
@@ -34,7 +34,7 @@ public data class Properties(
     /**
      * Serializes a [Properties] to its RWPM JSON representation.
      */
-    override fun toJSON(): JSONObject = JSONObject(otherProperties)
+    override fun toJSON(): JSONObject = JSONObject(HashMap(otherProperties))
 
     /**
      * Makes a copy of this [Properties] after merging in the given additional other [properties].


### PR DESCRIPTION
When building with R8 (minification enabled), `toJSON()` methods in `Locator.Locations`, `Locator.Metadata`, `Metadata`, and `Properties` crash with:

```
java.lang.UnsupportedOperationException: Operation is not supported for read-only collection
    at kotlin.collections.EmptyMap.remove(Maps.kt)
    at org.json.JSONObject.remove(JSONObject.java)
    at org.readium.r2.shared.extensions.JSONKt.putIfNotEmpty(JSON.kt)
    at org.readium.r2.shared.publication.Locator$Locations.toJSON(Locator.kt)
```

The issue is that these classes have `otherLocations`/`otherMetadata`/`otherProperties` fields that default to `emptyMap()`, which is Kotlin's immutable empty map singleton. When this gets passed to the `JSONObject(Map)` constructor, R8 can optimize away the internal copy into a `LinkedHashMap` (since the map is empty, the copy loop is a no-op and R8 eliminates it). This leaves the JSONObject backed by the immutable `EmptyMap`, and then any call to `putIfNotEmpty` that triggers `remove()` crashes.

The fix just wraps the map in `HashMap()` before passing it to the JSONObject constructor so it's always mutable.

Hit this in my app targeting API 36 with AGP 8.13 / R8 full mode, on the `notifyCurrentLocation` flow in `EpubNavigatorFragment`.