### PR TITLE
Fix Dokka

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ hooks:
   - docs/scripts/hooks.py
 
 exclude_docs: |
-  scripts/
+  /scripts/
 
 validation:
   links:


### PR DESCRIPTION
Dokka has a scripts folder now, and the mkdocs file was excluding all folders named `scripts/`. We only want to exclude the root scripts folder, so changed it to `/scripts/`.