### PR TITLE
Fix poorly-authored EPUB links not navigating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Shared
+
+* EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
@@ -86,6 +86,16 @@ internal fun String.percentEncodedQuery(): String =
     Uri.encode(this, "$+,/?:=@")
 
 /**
+ * Percent-encodes the invalid characters of a full URL query or fragment.
+ *
+ * Contrary to [percentEncodedQuery], which encodes an individual query key or value, this preserves
+ * the structural characters of a full query or fragment (such as `&`, `;` and `=`), only encoding
+ * the genuinely invalid ones (e.g. spaces).
+ */
+internal fun String.percentEncodedQueryOrFragment(): String =
+    Uri.encode(this, "$&+,/:;=?@")
+
+/**
  * Returns whether the String receiver contains only printable ASCII characters.
  */
 internal fun String.isPrintableAscii(): Boolean =

--- a/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/extensions/String.kt
@@ -91,9 +91,12 @@ internal fun String.percentEncodedQuery(): String =
  * Contrary to [percentEncodedQuery], which encodes an individual query key or value, this preserves
  * the structural characters of a full query or fragment (such as `&`, `;` and `=`), only encoding
  * the genuinely invalid ones (e.g. spaces).
+ *
+ * `%` is left untouched so that existing percent escapes (e.g. `%20`) are preserved instead of being
+ * double-encoded into `%2520` when a partially-encoded query/fragment triggers this fallback.
  */
 internal fun String.percentEncodedQueryOrFragment(): String =
-    Uri.encode(this, "$&+,/:;=?@")
+    Uri.encode(this, "$&+,/:;=?@%")
 
 /**
  * Returns whether the String receiver contains only printable ASCII characters.

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Link.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Link.kt
@@ -207,16 +207,27 @@ public data class Link(
 }
 
 /**
- * Returns the first [Link] with the given [href], or null if not found.
+ * Returns the index of the first [Link] with the given [href], or null if not found.
+ *
+ * Falls back to ignoring the query and fragment of [href], to stay consistent with
+ * [Manifest.linkWithHref].
  */
-public fun List<Link>.indexOfFirstWithHref(href: Url): Int? =
-    indexOfFirst { it.url().isEquivalent(href) }
-        .takeUnless { it == -1 }
+public fun List<Link>.indexOfFirstWithHref(href: Url): Int? {
+    fun index(href: Url): Int? =
+        indexOfFirst { it.url().isEquivalent(href) }.takeUnless { it == -1 }
+
+    return index(href)
+        ?: index(href.removeQuery().removeFragment())
+}
 
 /**
- * Finds the first link matching the given HREF.
+ * Finds the first [Link] with the given [href], or null if not found.
+ *
+ * Falls back to ignoring the query and fragment of [href], to stay consistent with
+ * [Manifest.linkWithHref].
  */
-public fun List<Link>.firstWithHref(href: Url): Link? = firstOrNull { it.url().isEquivalent(href) }
+public fun List<Link>.firstWithHref(href: Url): Link? =
+    indexOfFirstWithHref(href)?.let { this[it] }
 
 /**
  * Finds the first link with the given relation.

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Link.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Link.kt
@@ -209,7 +209,7 @@ public data class Link(
 /**
  * Returns the index of the first [Link] with the given [href], or null if not found.
  *
- * Falls back to ignoring the query and fragment of [href], to stay consistent with
+ * Falls back to ignoring the fragment, then the query too, of [href], to stay consistent with
  * [Manifest.linkWithHref].
  */
 public fun List<Link>.indexOfFirstWithHref(href: Url): Int? {
@@ -217,13 +217,14 @@ public fun List<Link>.indexOfFirstWithHref(href: Url): Int? {
         indexOfFirst { it.url().isEquivalent(href) }.takeUnless { it == -1 }
 
     return index(href)
-        ?: index(href.removeQuery().removeFragment())
+        ?: index(href.removeFragment())
+        ?: index(href.removeFragment().removeQuery())
 }
 
 /**
  * Finds the first [Link] with the given [href], or null if not found.
  *
- * Falls back to ignoring the query and fragment of [href], to stay consistent with
+ * Falls back to ignoring the fragment, then the query too, of [href], to stay consistent with
  * [Manifest.linkWithHref].
  */
 public fun List<Link>.firstWithHref(href: Url): Link? =

--- a/readium/shared/src/main/java/org/readium/r2/shared/publication/Manifest.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/publication/Manifest.kt
@@ -64,7 +64,7 @@ public data class Manifest(
      * Searches through (in order) [readingOrder], [resources] and [links] recursively following
      * alternate and children links.
      *
-     * If there's no match, tries again after removing any query parameter and anchor from the
+     * If there's no match, tries again after removing the fragment, then the query too, from the
      * given [href].
      */
     @OptIn(DelicateReadiumApi::class)
@@ -89,6 +89,7 @@ public data class Manifest(
 
         val normalizedHref = href.normalize()
         return find(normalizedHref)
+            ?: find(normalizedHref.removeFragment())
             ?: find(normalizedHref.removeFragment().removeQuery())
     }
 

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
@@ -388,10 +388,32 @@ public fun Url.Companion.fromLegacyHref(href: String): Url? =
  *
  * As a workaround, we assume the HREFs are valid percent-encoded URLs, and fallback to decoded paths
  * if we can't parse the URL.
+ *
+ * When falling back to a decoded path, only the path portion is percent-encoded: any `?query` and
+ * `#fragment` are split off and reattached verbatim. This keeps their `?`/`#` separators intact (a
+ * plain path encoding would turn them into `%3F`/`%23`) and preserves any existing encoding in the
+ * query or fragment instead of double-encoding it.
  */
 @InternalReadiumApi
-public fun Url.Companion.fromEpubHref(href: String): Url? =
-    Url(href) ?: fromDecodedPath(href)
+public fun Url.Companion.fromEpubHref(href: String): Url? {
+    // A well-formed HREF is already a valid percent-encoded URL.
+    Url(href)?.let { return it }
+
+    // Otherwise the HREF is not a valid URL (e.g. a decoded path containing spaces). Split off the
+    // query and fragment, encode only the path, then reassemble. The path ends at the first `?` or
+    // `#`: since the query always precedes the fragment in a URL, a `?` occurring inside a fragment
+    // is left in the suffix rather than mistaken for a query separator.
+    val splitIndex = href.indexOfFirst { it == '?' || it == '#' }
+    val pathPart = if (splitIndex < 0) href else href.substring(0, splitIndex)
+    val suffix = if (splitIndex < 0) "" else href.substring(splitIndex)
+
+    val pathUrl = fromDecodedPath(pathPart) ?: return null
+
+    // The suffix is reattached verbatim. Note this can degrade for malformed input: `Url()` parses
+    // via Java's stricter `URI`, so a raw space inside the query/fragment (e.g. `foo.xhtml#a b`)
+    // fails to re-parse and we fall back to `pathUrl` without the suffix.
+    return Url(pathUrl.toString() + suffix) ?: pathUrl
+}
 
 /**
  * Creates a URL pointing to this [File] which must denote an absolute path.

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
@@ -389,11 +389,6 @@ public fun Url.Companion.fromLegacyHref(href: String): Url? =
  *
  * As a workaround, we assume the HREFs are valid percent-encoded URLs, and fallback to decoded paths
  * if we can't parse the URL.
- *
- * When falling back to a decoded path, the path, query and fragment are encoded independently, so
- * that their `?`/`#` separators stay intact (a plain path encoding would turn them into `%3F`/`%23`).
- * Each component follows the same policy: if it already forms a valid percent-encoded URL, it is
- * kept verbatim to avoid double-encoding; otherwise its invalid characters are encoded.
  */
 @InternalReadiumApi
 public fun Url.Companion.fromEpubHref(href: String): Url? {

--- a/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
+++ b/readium/shared/src/main/java/org/readium/r2/shared/util/Url.kt
@@ -19,6 +19,7 @@ import org.readium.r2.shared.DelicateReadiumApi
 import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.extensions.isPrintableAscii
 import org.readium.r2.shared.extensions.percentEncodedPath
+import org.readium.r2.shared.extensions.percentEncodedQueryOrFragment
 import org.readium.r2.shared.extensions.tryOrNull
 
 /**
@@ -389,10 +390,10 @@ public fun Url.Companion.fromLegacyHref(href: String): Url? =
  * As a workaround, we assume the HREFs are valid percent-encoded URLs, and fallback to decoded paths
  * if we can't parse the URL.
  *
- * When falling back to a decoded path, only the path portion is percent-encoded: any `?query` and
- * `#fragment` are split off and reattached verbatim. This keeps their `?`/`#` separators intact (a
- * plain path encoding would turn them into `%3F`/`%23`) and preserves any existing encoding in the
- * query or fragment instead of double-encoding it.
+ * When falling back to a decoded path, the path, query and fragment are encoded independently, so
+ * that their `?`/`#` separators stay intact (a plain path encoding would turn them into `%3F`/`%23`).
+ * Each component follows the same policy: if it already forms a valid percent-encoded URL, it is
+ * kept verbatim to avoid double-encoding; otherwise its invalid characters are encoded.
  */
 @InternalReadiumApi
 public fun Url.Companion.fromEpubHref(href: String): Url? {
@@ -400,19 +401,38 @@ public fun Url.Companion.fromEpubHref(href: String): Url? {
     Url(href)?.let { return it }
 
     // Otherwise the HREF is not a valid URL (e.g. a decoded path containing spaces). Split off the
-    // query and fragment, encode only the path, then reassemble. The path ends at the first `?` or
-    // `#`: since the query always precedes the fragment in a URL, a `?` occurring inside a fragment
-    // is left in the suffix rather than mistaken for a query separator.
+    // query and fragment, so each component can be encoded independently. The path ends at the first
+    // `?` or `#`: since the query always precedes the fragment in a URL, a `?` occurring inside a
+    // fragment is left in the suffix rather than mistaken for a query separator.
     val splitIndex = href.indexOfFirst { it == '?' || it == '#' }
     val pathPart = if (splitIndex < 0) href else href.substring(0, splitIndex)
     val suffix = if (splitIndex < 0) "" else href.substring(splitIndex)
 
     val pathUrl = fromDecodedPath(pathPart) ?: return null
 
-    // The suffix is reattached verbatim. Note this can degrade for malformed input: `Url()` parses
-    // via Java's stricter `URI`, so a raw space inside the query/fragment (e.g. `foo.xhtml#a b`)
-    // fails to re-parse and we fall back to `pathUrl` without the suffix.
-    return Url(pathUrl.toString() + suffix) ?: pathUrl
+    // Reattach the query and fragment. First try them verbatim, so an already-encoded suffix is not
+    // double-encoded. If that fails to parse (e.g. a raw space inside the query/fragment), encode
+    // their invalid characters while preserving the `?`/`#` separators and query structure.
+    Url(pathUrl.toString() + suffix)?.let { return it }
+    return Url(pathUrl.toString() + encodeEpubHrefSuffix(suffix)) ?: pathUrl
+}
+
+/**
+ * Percent-encodes the invalid characters of an EPUB HREF [suffix] (`?query#fragment`), keeping the
+ * `?`/`#` separators and the query/fragment structural characters (e.g. `&`, `=`) intact.
+ */
+private fun encodeEpubHrefSuffix(suffix: String): String {
+    val fragmentIndex = suffix.indexOf('#')
+    val query = if (fragmentIndex < 0) suffix else suffix.substring(0, fragmentIndex)
+    val fragment = if (fragmentIndex < 0) "" else suffix.substring(fragmentIndex)
+
+    // Encodes a single component while keeping its leading `?`/`#` separator intact.
+    fun encodeComponent(component: String, separator: Char): String =
+        component.takeIf { it.startsWith(separator) }
+            ?.let { separator + it.drop(1).percentEncodedQueryOrFragment() }
+            ?: component
+
+    return encodeComponent(query, '?') + encodeComponent(fragment, '#')
 }
 
 /**

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/LinkTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/LinkTest.kt
@@ -328,4 +328,24 @@ class LinkTest {
             ).indexOfFirstWithHref(Url("href2")!!)
         )
     }
+
+    @Test
+    fun `Find a {Link} in a list ignoring the query and fragment as a fallback`() {
+        val links = listOf(Link(href = Url("l1")!!), Link(href = Url("l2")!!))
+
+        // firstWithHref falls back to ignoring the query and fragment.
+        assertEquals(Link(href = Url("l2")!!), links.firstWithHref(Url("l2#fragment")!!))
+        assertEquals(Link(href = Url("l2")!!), links.firstWithHref(Url("l2?query=1")!!))
+        assertEquals(Link(href = Url("l2")!!), links.firstWithHref(Url("l2?query=1#fragment")!!))
+
+        // indexOfFirstWithHref falls back to ignoring the query and fragment.
+        assertEquals(1, links.indexOfFirstWithHref(Url("l2#fragment")!!))
+        assertEquals(1, links.indexOfFirstWithHref(Url("l2?query=1#fragment")!!))
+    }
+
+    @Test
+    fun `An exact {href} match takes precedence over the query and fragment fallback`() {
+        val links = listOf(Link(href = Url("l2")!!), Link(href = Url("l2?query=1")!!))
+        assertEquals(1, links.indexOfFirstWithHref(Url("l2?query=1")!!))
+    }
 }

--- a/readium/shared/src/test/java/org/readium/r2/shared/publication/LinkTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/publication/LinkTest.kt
@@ -348,4 +348,11 @@ class LinkTest {
         val links = listOf(Link(href = Url("l2")!!), Link(href = Url("l2?query=1")!!))
         assertEquals(1, links.indexOfFirstWithHref(Url("l2?query=1")!!))
     }
+
+    @Test
+    fun `Removing only the fragment takes precedence over removing the query too`() {
+        val links = listOf(Link(href = Url("l2")!!), Link(href = Url("l2?query=1")!!))
+        // The link keeping the query is preferred over the one without it.
+        assertEquals(1, links.indexOfFirstWithHref(Url("l2?query=1#fragment")!!))
+    }
 }

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
@@ -84,6 +84,55 @@ class UrlTest {
         assertEquals(expected, url.toString())
     }
 
+    @OptIn(InternalReadiumApi::class)
+    @Test
+    fun createFromEpubHref() {
+        fun testEpub(href: String, expected: String) {
+            val url = Url.fromEpubHref(href)
+            assertNotNull(url)
+            assertEquals(expected, url.toString())
+        }
+
+        // Valid percent-encoded HREFs are used as-is.
+        testEpub("dir/chapter.xhtml", "dir/chapter.xhtml")
+        testEpub("dir/chapter.xhtml#frag", "dir/chapter.xhtml#frag")
+        testEpub("dir/chapter.xhtml?q=1#frag", "dir/chapter.xhtml?q=1#frag")
+        // Already-encoded characters are not re-encoded.
+        testEpub("dir/chapter%20one.xhtml#frag", "dir/chapter%20one.xhtml#frag")
+
+        // Decoded paths without separators are percent-encoded.
+        testEpub("dir/chapter one.xhtml", "dir/chapter%20one.xhtml")
+        testEpub("/dir/chapter one.xhtml", "/dir/chapter%20one.xhtml")
+
+        // When the path is not percent-encoded, only the path is encoded while the `?query` and
+        // `#fragment` — and their separators — are preserved verbatim.
+        testEpub(
+            "../content/Harry Potter 1.xhtml#fragment-01",
+            "../content/Harry%20Potter%201.xhtml#fragment-01"
+        )
+        testEpub("/dir/my file.xhtml#frag", "/dir/my%20file.xhtml#frag")
+        testEpub("dir/my file.xhtml?q=1", "dir/my%20file.xhtml?q=1")
+        testEpub("dir/my file.xhtml?q=1#frag", "dir/my%20file.xhtml?q=1#frag")
+
+        // An already-encoded fragment is not double-encoded.
+        testEpub("hello world#properly%20encoded", "hello%20world#properly%20encoded")
+
+        // A question mark inside the fragment is kept in the fragment.
+        testEpub("dir/a b.xhtml#f?x", "dir/a%20b.xhtml#f?x")
+
+        // Media Overlays clip URL (from the SMIL parser): the comma is valid in a fragment and is
+        // kept, while the space in the path is encoded.
+        testEpub("audio/my file.mp3#t=0.5,10.2", "audio/my%20file.mp3#t=0.5,10.2")
+
+        // Degradation: a raw space in the fragment is invalid for Java's URI parser, so reassembly
+        // fails and we fall back to the path-only encoding. The malformed fragment is dropped rather
+        // than smuggled into the path.
+        testEpub("chapter one.xhtml#foo bar", "chapter%20one.xhtml")
+
+        // Returns null for an empty HREF.
+        assertNull(Url.fromEpubHref(""))
+    }
+
     @Test
     fun createFromFragmentOnly() {
         assertEquals(RelativeUrl(Uri.parse("#fragment")), Url("#fragment"))

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
@@ -84,7 +84,6 @@ class UrlTest {
         assertEquals(expected, url.toString())
     }
 
-    @OptIn(InternalReadiumApi::class)
     @Test
     fun createFromEpubHref() {
         fun testEpub(href: String, expected: String) {

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
@@ -131,6 +131,11 @@ class UrlTest {
         testEpub("chapter one.xhtml?a b#c d", "chapter%20one.xhtml?a%20b#c%20d")
         // The query structure (`&` and `=`) is preserved while invalid characters are encoded.
         testEpub("my file.xhtml?a=b c&d=e", "my%20file.xhtml?a=b%20c&d=e")
+        // A partially-encoded query or fragment keeps its existing percent escapes instead of
+        // double-encoding them (`%20` must stay `%20`, not become `%2520`) when a raw space forces
+        // the fallback encoding.
+        testEpub("my file.xhtml#foo%20bar baz", "my%20file.xhtml#foo%20bar%20baz")
+        testEpub("my file.xhtml?a=b%20c&d=e f", "my%20file.xhtml?a=b%20c&d=e%20f")
 
         // Returns null for an empty HREF.
         assertNull(Url.fromEpubHref(""))

--- a/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
+++ b/readium/shared/src/test/java/org/readium/r2/shared/util/UrlTest.kt
@@ -123,10 +123,14 @@ class UrlTest {
         // kept, while the space in the path is encoded.
         testEpub("audio/my file.mp3#t=0.5,10.2", "audio/my%20file.mp3#t=0.5,10.2")
 
-        // Degradation: a raw space in the fragment is invalid for Java's URI parser, so reassembly
-        // fails and we fall back to the path-only encoding. The malformed fragment is dropped rather
-        // than smuggled into the path.
-        testEpub("chapter one.xhtml#foo bar", "chapter%20one.xhtml")
+        // A raw space in the fragment or query is invalid for Java's URI parser, so reassembly fails
+        // and we fall back to encoding the invalid characters of the query/fragment, following the
+        // same policy as the path.
+        testEpub("chapter one.xhtml#foo bar", "chapter%20one.xhtml#foo%20bar")
+        testEpub("chapter one.xhtml?foo bar", "chapter%20one.xhtml?foo%20bar")
+        testEpub("chapter one.xhtml?a b#c d", "chapter%20one.xhtml?a%20b#c%20d")
+        // The query structure (`&` and `=`) is preserved while invalid characters are encoded.
+        testEpub("my file.xhtml?a=b c&d=e", "my%20file.xhtml?a=b%20c&d=e")
 
         // Returns null for an empty HREF.
         assertNull(Url.fromEpubHref(""))

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParserTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParserTest.kt
@@ -41,6 +41,7 @@ class NavigationDocumentParserTest {
     private val navSection = parseNavigationDocument("navigation/nav-section.xhtml")
     private val navChildren = parseNavigationDocument("navigation/nav-children.xhtml")
     private val navEmpty = parseNavigationDocument("navigation/nav-empty.xhtml")
+    private val navUnencoded = parseNavigationDocument("navigation/nav-unencoded.xhtml")
 
     @Test
     fun `nav can be a non-direct descendant of body`() {
@@ -145,6 +146,24 @@ class NavigationDocumentParserTest {
         assertThat(navComplex["page-list"]).containsExactly(
             Link(title = "1", href = Href("OEBPS/xhtml/chapter1.xhtml#page1")!!),
             Link(title = "2", href = Href("OEBPS/xhtml/chapter1.xhtml#page2")!!)
+        )
+    }
+
+    @Test
+    fun `hrefs that are not percent-encoded keep their fragment and query`() {
+        assertThat(navUnencoded["toc"]).containsExactly(
+            Link(
+                title = "Chapter 1",
+                href = Href("OEBPS/xhtml/chapter%20one%201.xhtml#fragment-01")!!
+            ),
+            Link(
+                title = "Chapter 2",
+                href = Href("OEBPS/xhtml/chapter%20two%202.xhtml?title=intro#fragment-02")!!
+            ),
+            Link(
+                title = "Chapter 1, again",
+                href = Href("OEBPS/content/chapter%20one%201.xhtml#fragment-03")!!
+            )
         )
     }
 }

--- a/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/NcxParserTest.kt
+++ b/readium/streamer/src/test/java/org/readium/r2/streamer/parser/epub/NcxParserTest.kt
@@ -37,6 +37,7 @@ class NcxParserTest {
     private val ncxTitles = parseNavigationDocument("ncx/ncx-titles.ncx")
     private val ncxChildren = parseNavigationDocument("ncx/ncx-children.ncx")
     private val ncxEmpty = parseNavigationDocument("ncx/ncx-empty.ncx")
+    private val ncxUnencoded = parseNavigationDocument("ncx/ncx-unencoded.ncx")
 
     @Test
     fun `Newlines are trimmed from title`() {
@@ -116,6 +117,24 @@ class NcxParserTest {
         Assertions.assertThat(ncxComplex["page-list"]).containsExactly(
             Link(title = "1", href = Href("OEBPS/xhtml/chapter1.xhtml#page1")!!),
             Link(title = "2", href = Href("OEBPS/xhtml/chapter1.xhtml#page2")!!)
+        )
+    }
+
+    @Test
+    fun `src values that are not percent-encoded keep their fragment and query`() {
+        Assertions.assertThat(ncxUnencoded["toc"]).containsExactly(
+            Link(
+                title = "Chapter 1",
+                href = Href("OEBPS/content/chapter%20one%201.xhtml#fragment-01")!!
+            ),
+            Link(
+                title = "Chapter 2",
+                href = Href("OEBPS/content/chapter%20two%202.xhtml?title=intro#fragment-02")!!
+            ),
+            Link(
+                title = "Chapter 1, again",
+                href = Href("content/chapter%20one%201.xhtml#fragment-03")!!
+            )
         )
     }
 }

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/navigation/nav-unencoded.xhtml
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/navigation/nav-unencoded.xhtml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  <!-- HREFs are NOT percent-encoded (they contain spaces) yet carry URI
+       fragments and queries. Poorly authored EPUBs like this exist in the
+       wild, so Readium must keep the `#`/`?` as separators instead of
+       encoding them into the path. -->
+  <nav epub:type="toc">
+    <h2>Table of Contents</h2>
+    <ol>
+      <li><a href="chapter one 1.xhtml#fragment-01">Chapter 1</a></li>
+      <li><a href="chapter two 2.xhtml?title=intro#fragment-02">Chapter 2</a></li>
+      <li><a href="../content/chapter one 1.xhtml#fragment-03">Chapter 1, again</a></li>
+    </ol>
+  </nav>
+</body>
+</html>

--- a/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/ncx/ncx-unencoded.ncx
+++ b/readium/streamer/src/test/resources/org/readium/r2/streamer/parser/epub/ncx/ncx-unencoded.ncx
@@ -1,0 +1,23 @@
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <docTitle>
+    <text>Document Title</text>
+  </docTitle>
+
+  <!-- `src` values are NOT percent-encoded (they contain spaces) yet carry
+       URI fragments and queries. Readium must keep the `#`/`?` as separators
+       instead of encoding them into the path. -->
+  <navMap>
+    <navPoint>
+      <navLabel><text>Chapter 1</text></navLabel>
+      <content src="content/chapter one 1.xhtml#fragment-01"/>
+    </navPoint>
+    <navPoint>
+      <navLabel><text>Chapter 2</text></navLabel>
+      <content src="content/chapter two 2.xhtml?title=intro#fragment-02"/>
+    </navPoint>
+    <navPoint>
+      <navLabel><text>Chapter 1, again</text></navLabel>
+      <content src="../content/chapter one 1.xhtml#fragment-03"/>
+    </navPoint>
+  </navMap>
+</ncx>


### PR DESCRIPTION
### Fixed

#### Shared

* EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.

---

Here's a sample EPUB that can be used to reproduce the issue: 
[unencoded-hrefs.epub.zip](https://github.com/user-attachments/files/29794898/unencoded-hrefs.epub.zip)

Ported from https://github.com/readium/swift-toolkit/pull/847