### PR TITLE
Fixed page positions off by one in the PDFium adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,13 @@ All notable changes to this project will be documented in this file. Take a look
 
 #### Navigator
 
-* Fixed the Pdfium navigator reporting page positions off by one: `currentLocator` was
-  one page ahead of the visible page, the first page was never reported, and the last
-  page never updated `currentLocator` ([#812](https://github.com/readium/kotlin-toolkit/pull/812)).
-    * **You must migrate persisted `Locator` objects created by the Pdfium navigator**
-      (bookmarks, reading progression) — stored positions were one page too high. Use the
-      new `Publication.migrateLegacyPdfiumLocator()` helper in `readium-adapter-pdfium`,
-      and take a look at [the migration guide](docs/migration-guide.md).
-      
+* Fixed the PDFium adapter reporting page positions off by one: `currentLocator` was one page ahead of the visible page, the first page was never reported, and the last page never updated `currentLocator` (contributed by [@huttarl](https://github.com/readium/kotlin-toolkit/pull/812)).
+    * :warning: You must migrate the `Locator` objects created by the PDFium adapter and persisted in your database (e.g. bookmarks, reading progression), as their positions were one page too high. Use the new `Publication.migrateLegacyPdfiumLocator()` helper and take a look at [the migration guide](docs/migration-guide.md).
+
 #### Shared
 
 * EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ All notable changes to this project will be documented in this file. Take a look
   one page ahead of the visible page, the first page was never reported, and the last
   page never updated `currentLocator` ([#812](https://github.com/readium/kotlin-toolkit/pull/812)).
     * **You must migrate persisted `Locator` objects created by the Pdfium navigator**
-      (bookmarks, reading progression) — stored positions were one page too high. Take a
-      look at [the migration guide](docs/migration-guide.md).
+      (bookmarks, reading progression) — stored positions were one page too high. Use the
+      new `Publication.migrateLegacyPdfiumLocator()` helper in `readium-adapter-pdfium`,
+      and take a look at [the migration guide](docs/migration-guide.md).
       
 #### Shared
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Navigator
+
+* Fixed the Pdfium navigator reporting page positions off by one: `currentLocator` was
+  one page ahead of the visible page, the first page was never reported, and the last
+  page never updated `currentLocator` ([#812](https://github.com/readium/kotlin-toolkit/pull/812)).
+    * **You must migrate persisted `Locator` objects created by the Pdfium navigator**
+      (bookmarks, reading progression) — stored positions were one page too high. Take a
+      look at [the migration guide](docs/migration-guide.md).
 
 ## [3.3.0] - 2026-06-02
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -4,39 +4,32 @@ All migration steps necessary in reading apps to upgrade to major versions of th
 
 ## Unreleased
 
-### Pdfium navigator: page positions were off by one (bookmarks, reading progression)
+### Breaking changes with the PDFium adapter
 
-:warning: This requires a data migration in your application if you persisted `Locator`
-objects created by the Pdfium navigator (`readium-adapter-pdfium`).
+#### Page positions were off by one (bookmarks, reading progression)
 
-In previous versions, the Pdfium navigator reported page positions off by one:
-`currentLocator` carried a `locations.position` one page too high (visible page 1 was
-reported as position 2, and so on), and `locations.totalProgression` was shifted
-accordingly. The first page was never reported, and the last page never updated
-`currentLocator`.
+:warning: This requires a data migration in your application if you persisted `Locator` objects created by the PDFium adapter (`readium-adapter-pdfium`).
 
-The error canceled itself out when a stored locator was restored with the same Pdfium
-navigator — saving added one and restoring subtracted one — which is why it could go
-unnoticed. Now that the navigator is fixed, locators persisted with earlier versions
-will restore one page too far, whether with the Pdfium navigator or any other PDF
-engine.
+In previous versions, the PDFium navigator reported page positions off by one: `currentLocator` carried a `locations.position` one page too high (visible page 1 was reported as position 2, and so on), with the page fragment and the progressions shifted accordingly. The first page was never reported, and the last page never updated `currentLocator`.
 
-To migrate a stored `Locator` for a PDF publication, use the
-`Publication.migrateLegacyPdfiumLocator()` helper provided by `readium-adapter-pdfium`.
-It re-resolves the corrected page from the publication's position list, which also
-fixes `locations.totalProgression`:
+The error canceled itself out when a stored locator was restored with the same PDFium navigator. Now that the navigator is fixed, locators persisted with earlier versions will restore one page too far, whether with the PDFium navigator or any other PDF engine.
+
+To migrate a stored `Locator` for a PDF publication, use the `Publication.migrateLegacyPdfiumLocator()` helper provided by `readium-adapter-pdfium`. It re-resolves the corrected page from the publication's position list, keeping the title, text and any custom locations you attached to the locator:
 
 ```kotlin
 @OptIn(DelicateReadiumApi::class)
-suspend fun migrateStoredLocator(publication: Publication, locator: Locator): Locator =
-    publication.migrateLegacyPdfiumLocator(locator)
+suspend fun migrateBookmarks(publication: Publication) {
+    for (bookmark in bookmarkRepository.bookmarks(publication.id)) {
+        bookmarkRepository.update(
+            bookmark.copy(locator = publication.migrateLegacyPdfiumLocator(bookmark.locator))
+        )
+    }
+}
 ```
 
-Apply the migration once per stored locator, and only to locators created by the Pdfium
-navigator. Locators your app computed itself from `publication.positions()` are
-unaffected.
+Apply the migration once per stored locator, and only to locators created by the PDFium navigator. Locators your app computed itself from `publication.positions()` are unaffected.
 
-### PDF navigator (PDFium adapter)
+#### Layout is now paginated by default
 
 The PDFium adapter now defaults to a horizontal paginated layout, instead of a vertical continuous scroll. If your app relies on the previous behavior, enable the new `scroll` preference by default when creating the `PdfiumEngineProvider`:
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -27,17 +27,23 @@ publication's position list:
 ​```kotlin
 /**
  * Corrects a PDF [locator] persisted by the Pdfium navigator before this version.
- * Stored positions were one page too high; re-resolving from `positions()` also
- * corrects `totalProgression`.
+ *
+ * The navigator reported page indices one too high, so a stored `position` is
+ * `actual page + 1`. Re-resolving the corrected page from `positions()` also fixes
+ * `totalProgression`.
  */
 suspend fun migratePdfiumLocator(publication: Publication, locator: Locator): Locator {
     val position = locator.locations.position ?: return locator
-    // positions() is 0-based; a stored position N was created from page index N - 2.
+    // Two different -1s are stacked here, and only the first is the bug fix:
+    //   -1 to undo the off-by-one in the stored position;
+    //   -1 more to convert the (by-design) 1-based `position` into an index into the
+    //      0-based `positions()` list, whose element k carries `position == k + 1`.
+    // (`getOrNull(position - 1)` would be a no-op: it returns the element whose
+    // `position` equals the stored value.)
     return publication.positions().getOrNull(position - 2)
         ?: locator // Position 1 (only ever the initial value, i.e. page 1) or out of
                    // range: correct as-is, keep unchanged.
-}
-​```
+}```
 
 Apply the migration once per stored locator, and only to locators created by the Pdfium
 navigator. Locators your app computed itself from `publication.positions()` are

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -21,29 +21,15 @@ unnoticed. Now that the navigator is fixed, locators persisted with earlier vers
 will restore one page too far, whether with the Pdfium navigator or any other PDF
 engine.
 
-To migrate a stored `Locator` for a PDF publication, re-resolve it from the
-publication's position list:
+To migrate a stored `Locator` for a PDF publication, use the
+`Publication.migrateLegacyPdfiumLocator()` helper provided by `readium-adapter-pdfium`.
+It re-resolves the corrected page from the publication's position list, which also
+fixes `locations.totalProgression`:
 
 ```kotlin
-/**
- * Corrects a PDF [locator] persisted by the Pdfium navigator before this version.
- *
- * The navigator reported page indices one too high, so a stored `position` is
- * `actual page + 1`. Re-resolving the corrected page from `positions()` also fixes
- * `totalProgression`.
- */
-suspend fun migratePdfiumLocator(publication: Publication, locator: Locator): Locator {
-    val position = locator.locations.position ?: return locator
-    // Two different -1s are stacked here, and only the first is the bug fix:
-    //   -1 to undo the off-by-one in the stored position;
-    //   -1 more to convert the (by-design) 1-based `position` into an index into the
-    //      0-based `positions()` list, whose element k carries `position == k + 1`.
-    // (`getOrNull(position - 1)` would be a no-op: it returns the element whose
-    // `position` equals the stored value.)
-    return publication.positions().getOrNull(position - 2)
-        ?: locator // Position 1 (only ever the initial value, i.e. page 1) or out of
-                   // range: correct as-is, keep unchanged.
-}
+@OptIn(DelicateReadiumApi::class)
+suspend fun migrateStoredLocator(publication: Publication, locator: Locator): Locator =
+    publication.migrateLegacyPdfiumLocator(locator)
 ```
 
 Apply the migration once per stored locator, and only to locators created by the Pdfium

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,7 +2,46 @@
 
 All migration steps necessary in reading apps to upgrade to major versions of the Kotlin Readium toolkit will be documented in this file.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Pdfium navigator: page positions were off by one (bookmarks, reading progression)
+
+:warning: This requires a data migration in your application if you persisted `Locator`
+objects created by the Pdfium navigator (`readium-adapter-pdfium`).
+
+In previous versions, the Pdfium navigator reported page positions off by one:
+`currentLocator` carried a `locations.position` one page too high (visible page 1 was
+reported as position 2, and so on), and `locations.totalProgression` was shifted
+accordingly. The first page was never reported, and the last page never updated
+`currentLocator`.
+
+The error canceled itself out when a stored locator was restored with the same Pdfium
+navigator — saving added one and restoring subtracted one — which is why it could go
+unnoticed. Now that the navigator is fixed, locators persisted with earlier versions
+will restore one page too far, whether with the Pdfium navigator or any other PDF
+engine.
+
+To migrate a stored `Locator` for a PDF publication, re-resolve it from the
+publication's position list:
+
+​```kotlin
+/**
+ * Corrects a PDF [locator] persisted by the Pdfium navigator before this version.
+ * Stored positions were one page too high; re-resolving from `positions()` also
+ * corrects `totalProgression`.
+ */
+suspend fun migratePdfiumLocator(publication: Publication, locator: Locator): Locator {
+    val position = locator.locations.position ?: return locator
+    // positions() is 0-based; a stored position N was created from page index N - 2.
+    return publication.positions().getOrNull(position - 2)
+        ?: locator // Position 1 (only ever the initial value, i.e. page 1) or out of
+                   // range: correct as-is, keep unchanged.
+}
+​```
+
+Apply the migration once per stored locator, and only to locators created by the Pdfium
+navigator. Locators your app computed itself from `publication.positions()` are
+unaffected.
 
 ## 3.0.0
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -24,7 +24,7 @@ engine.
 To migrate a stored `Locator` for a PDF publication, re-resolve it from the
 publication's position list:
 
-​```kotlin
+```kotlin
 /**
  * Corrects a PDF [locator] persisted by the Pdfium navigator before this version.
  *
@@ -43,7 +43,8 @@ suspend fun migratePdfiumLocator(publication: Publication, locator: Locator): Lo
     return publication.positions().getOrNull(position - 2)
         ?: locator // Position 1 (only ever the initial value, i.e. page 1) or out of
                    // range: correct as-is, keep unchanged.
-}```
+}
+```
 
 Apply the migration once per stored locator, and only to locators created by the Pdfium
 navigator. Locators your app computed itself from `publication.positions()` are

--- a/readium/adapters/pdfium/navigator/build.gradle.kts
+++ b/readium/adapters/pdfium/navigator/build.gradle.kts
@@ -28,4 +28,9 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
 }

--- a/readium/adapters/pdfium/navigator/src/main/java/org/readium/adapter/pdfium/navigator/LegacyLocatorMigration.kt
+++ b/readium/adapters/pdfium/navigator/src/main/java/org/readium/adapter/pdfium/navigator/LegacyLocatorMigration.kt
@@ -15,9 +15,9 @@ import org.readium.r2.shared.publication.services.positions
  * Corrects a PDF [locator] persisted by the Pdfium navigator before the page-index fix,
  * by re-resolving it from this publication's position list.
  *
- * The navigator used to report page positions one too high: a stored
- * `locations.position` is `actual page + 1`, and `locations.totalProgression` is shifted
- * accordingly. Re-resolving the corrected page from `positions()` fixes both.
+ * The Pdfium navigator used to report page positions one too high: a stored
+ * `locations.position` is `actual page + 1`, and the page fragment and progressions are
+ * shifted accordingly.
  *
  * Only use this API when you are upgrading and migrating the locators (bookmarks,
  * reading progression) stored in your database, and only for locators created by the
@@ -27,14 +27,21 @@ import org.readium.r2.shared.publication.services.positions
  */
 @DelicateReadiumApi
 public suspend fun Publication.migrateLegacyPdfiumLocator(locator: Locator): Locator {
-    val position = locator.locations.position ?: return locator
-    // Two different -1s are stacked here, and only the first is the bug fix:
-    //   -1 to undo the off-by-one in the stored position;
-    //   -1 more to convert the (by-design) 1-based `position` into an index into the
-    //      0-based `positions()` list, whose element k carries `position == k + 1`.
-    // (`getOrNull(position - 1)` would be a no-op: it returns the element whose
-    // `position` equals the stored value.)
-    return positions().getOrNull(position - 2)
-        ?: locator // Position 1 (only ever the initial value, i.e. page 1) or out of
-    // range: correct as-is, keep unchanged.
+    val storedPosition = locator.locations.position ?: return locator
+    // Undo the off-by-one to get the position of the page actually being read.
+    val correctedPosition = storedPosition - 1
+    // `position` is 1-based by design, while `positions()` is a 0-based list whose
+    // element k carries `position == k + 1`.
+    val corrected = positions().getOrNull(correctedPosition - 1)
+        // Position 1 (only ever the initial value, i.e. page 1) or out of range: keep
+        // the locator unchanged.
+        ?: return locator
+
+    // The whole locations are replaced, as the page fragment and the progressions are
+    // shifted as well and must stay consistent with the position.
+    return locator.copy(
+        locations = corrected.locations.copy(
+            otherLocations = locator.locations.otherLocations + corrected.locations.otherLocations
+        )
+    )
 }

--- a/readium/adapters/pdfium/navigator/src/main/java/org/readium/adapter/pdfium/navigator/LegacyLocatorMigration.kt
+++ b/readium/adapters/pdfium/navigator/src/main/java/org/readium/adapter/pdfium/navigator/LegacyLocatorMigration.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.adapter.pdfium.navigator
+
+import org.readium.r2.shared.DelicateReadiumApi
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.positions
+
+/**
+ * Corrects a PDF [locator] persisted by the Pdfium navigator before the page-index fix,
+ * by re-resolving it from this publication's position list.
+ *
+ * The navigator used to report page positions one too high: a stored
+ * `locations.position` is `actual page + 1`, and `locations.totalProgression` is shifted
+ * accordingly. Re-resolving the corrected page from `positions()` fixes both.
+ *
+ * Only use this API when you are upgrading and migrating the locators (bookmarks,
+ * reading progression) stored in your database, and only for locators created by the
+ * Pdfium navigator — locators your app computed itself from `positions()` are
+ * unaffected. Apply it once per stored locator. See the migration guide for more
+ * information.
+ */
+@DelicateReadiumApi
+public suspend fun Publication.migrateLegacyPdfiumLocator(locator: Locator): Locator {
+    val position = locator.locations.position ?: return locator
+    // Two different -1s are stacked here, and only the first is the bug fix:
+    //   -1 to undo the off-by-one in the stored position;
+    //   -1 more to convert the (by-design) 1-based `position` into an index into the
+    //      0-based `positions()` list, whose element k carries `position == k + 1`.
+    // (`getOrNull(position - 1)` would be a no-op: it returns the element whose
+    // `position` equals the stored value.)
+    return positions().getOrNull(position - 2)
+        ?: locator // Position 1 (only ever the initial value, i.e. page 1) or out of
+    // range: correct as-is, keep unchanged.
+}

--- a/readium/adapters/pdfium/navigator/src/main/java/org/readium/adapter/pdfium/navigator/PdfiumDocumentFragment.kt
+++ b/readium/adapters/pdfium/navigator/src/main/java/org/readium/adapter/pdfium/navigator/PdfiumDocumentFragment.kt
@@ -164,21 +164,14 @@ public class PdfiumDocumentFragment internal constructor(
         return validRange.contains(pageIndex)
     }
 
-    private fun convertPageIndexToView(page: Int): Int {
-        var index = (page - 1).coerceAtLeast(0)
-        if (isPagesOrderReversed) {
-            index = (pageCount - 1) - index
-        }
-        return index
-    }
+    // Both indices are 0-based: `pageIndex` is the navigator-facing index into
+    // publication.positions(), while `viewPageIndex` is the PDFView page index. They
+    // differ only when the page order is reversed for right-to-left reading progressions.
+    private fun convertPageIndexToView(pageIndex: Int): Int =
+        if (isPagesOrderReversed) (pageCount - 1) - pageIndex else pageIndex
 
-    private fun convertPageIndexFromView(index: Int): Int {
-        var page = index + 1
-        if (isPagesOrderReversed) {
-            page = (pageCount + 1) - page
-        }
-        return page
-    }
+    private fun convertPageIndexFromView(viewPageIndex: Int): Int =
+        if (isPagesOrderReversed) (pageCount - 1) - viewPageIndex else viewPageIndex
 
     /**
      * Indicates whether the order of the [PDFView] pages is reversed to take into account

--- a/readium/adapters/pdfium/navigator/src/test/java/org/readium/adapter/pdfium/navigator/LegacyLocatorMigrationTest.kt
+++ b/readium/adapters/pdfium/navigator/src/test/java/org/readium/adapter/pdfium/navigator/LegacyLocatorMigrationTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.adapter.pdfium.navigator
+
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.DelicateReadiumApi
+import org.readium.r2.shared.publication.Href
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.LocalizedString
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Manifest
+import org.readium.r2.shared.publication.Metadata
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.PositionsService
+import org.readium.r2.shared.publication.services.positionsServiceFactory
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(DelicateReadiumApi::class)
+@RunWith(RobolectricTestRunner::class)
+class LegacyLocatorMigrationTest {
+
+    private val href = Url("document.pdf")!!
+
+    // A 3-page PDF, as `PdfPositionsService` reports it.
+    private val positions = (1..3).map { position ->
+        Locator(
+            href = href,
+            mediaType = MediaType.PDF,
+            locations = Locator.Locations(
+                fragments = listOf("page=$position"),
+                progression = (position - 1) / 3.0,
+                position = position,
+                totalProgression = (position - 1) / 3.0
+            )
+        )
+    }
+
+    private val publication = Publication(
+        manifest = Manifest(
+            metadata = Metadata(localizedTitle = LocalizedString("Title")),
+            readingOrder = listOf(Link(href = Href(href.toString())!!, mediaType = MediaType.PDF))
+        ),
+        servicesBuilder = Publication.ServicesBuilder().apply {
+            positionsServiceFactory = {
+                object : PositionsService {
+                    override suspend fun positionsByReadingOrder(): List<List<Locator>> =
+                        listOf(positions)
+                }
+            }
+        }
+    )
+
+    // A locator persisted by the legacy navigator, which stored the whole `positions()`
+    // element it was given — but for the page after the visible one.
+    private fun storedLocator(
+        position: Int?,
+        text: Locator.Text = Locator.Text(),
+        otherLocations: Map<String, Any> = emptyMap(),
+    ) = Locator(
+        href = href,
+        mediaType = MediaType.PDF,
+        title = "Bookmark",
+        text = text,
+        locations = Locator.Locations(
+            fragments = position?.let { listOf("page=$it") } ?: emptyList(),
+            progression = position?.let { (it - 1) / 3.0 },
+            position = position,
+            totalProgression = position?.let { (it - 1) / 3.0 },
+            otherLocations = otherLocations
+        )
+    )
+
+    @Test
+    fun `shifts the position back by one`() = runTest {
+        // Page 2 was stored as position 3.
+        val migrated = publication.migrateLegacyPdfiumLocator(storedLocator(position = 3))
+
+        assertEquals(2, migrated.locations.position)
+        assertEquals(1 / 3.0, migrated.locations.progression)
+        assertEquals(1 / 3.0, migrated.locations.totalProgression)
+    }
+
+    @Test
+    fun `shifts the page fragment back by one`() = runTest {
+        // The navigator resolves `page` before `position`, so a stale fragment would
+        // make the migration a no-op.
+        val migrated = publication.migrateLegacyPdfiumLocator(storedLocator(position = 3))
+
+        assertEquals(listOf("page=2"), migrated.locations.fragments)
+    }
+
+    @Test
+    fun `preserves the title, text and other locations`() = runTest {
+        val text = Locator.Text(highlight = "Highlight")
+        val migrated = publication.migrateLegacyPdfiumLocator(
+            storedLocator(position = 3, text = text, otherLocations = mapOf("custom" to "value"))
+        )
+
+        assertEquals("Bookmark", migrated.title)
+        assertEquals(text, migrated.text)
+        assertEquals(mapOf("custom" to "value"), migrated.locations.otherLocations)
+    }
+
+    @Test
+    fun `keeps a locator without a position unchanged`() = runTest {
+        val locator = storedLocator(position = null)
+        assertEquals(locator, publication.migrateLegacyPdfiumLocator(locator))
+    }
+
+    @Test
+    fun `keeps position 1 unchanged`() = runTest {
+        // Position 1 is only ever the initial value, never a page reported by the
+        // legacy navigator.
+        val locator = storedLocator(position = 1)
+        assertEquals(locator, publication.migrateLegacyPdfiumLocator(locator))
+    }
+
+    @Test
+    fun `keeps an out of range position unchanged`() = runTest {
+        val locator = storedLocator(position = 42)
+        assertEquals(locator, publication.migrateLegacyPdfiumLocator(locator))
+    }
+}


### PR DESCRIPTION
The navigator-facing pageIndex contract has been 0-based since the PDF engine extraction in #129: PdfNavigatorFragment previously subtracted 1 before setting the locator value, and when that logic moved to PdfNavigatorViewModel the subtraction was dropped. The conversion methods moved into PdfiumDocumentFragment in the same refactoring kept the old 1-based assumption, so currentLocator reported every page one too high, the first page was never reported, and the last page's locator update was dropped.

Rename the converters' parameters to make the two 0-based conventions explicit (navigator pageIndex vs. PDFView viewPageIndex). The PSPDFKit adapter is unaffected (it passes PSPDFKit's already-0-based index through without conversion).

Fixes issue #811.