### PR TITLE
Fix crash when the liblcp native library cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
 
+#### LCP
+
+* [#796](https://github.com/readium/kotlin-toolkit/issues/796) Fixed a crash (`UnsatisfiedLinkError`) when the `liblcp` native library cannot be loaded, for example on some rooted devices. `LcpService()` now returns `null` in this case too, and logs the cause with Timber.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LcpClient.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LcpClient.kt
@@ -6,7 +6,7 @@ import java.lang.reflect.InvocationTargetException
 import org.readium.r2.lcp.LcpError
 import org.readium.r2.lcp.LcpException
 import org.readium.r2.shared.InternalReadiumApi
-import org.readium.r2.shared.extensions.tryOr
+import timber.log.Timber
 
 internal object LcpClient {
 
@@ -47,10 +47,17 @@ internal object LcpClient {
         Class.forName("org.readium.lcp.sdk.Lcp")
     }
 
-    fun isAvailable(): Boolean = tryOr(false) {
-        instance
-        true
-    }
+    fun isAvailable(): Boolean =
+        try {
+            instance
+            true
+        } catch (e: Throwable) {
+            // We catch any Throwable instead of Exception, because loading the liblcp native
+            // library can fail with an UnsatisfiedLinkError, which is an Error.
+            // See https://github.com/readium/kotlin-toolkit/issues/796
+            Timber.e(e, "The Readium LCP library is unavailable")
+            false
+        }
 
     fun createContext(jsonLicense: String, hashedPassphrases: String, pemCrl: String): Context =
         try {


### PR DESCRIPTION
`LcpClient.isAvailable()` relied on `tryOr`, which only catches `Exception`. When loading `liblcp.so` fails — e.g. on some rooted devices or with Xposed — an `UnsatisfiedLinkError` (an `Error`) escaped and crashed the app instead of making `LcpService()` return `null` as documented.

`isAvailable()` now catches `Throwable` and logs the cause with Timber, so integrators can diagnose why LCP is unavailable in the field.

Fixes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)