### PR TITLE
Add consumer Proguard rules for the LCP module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
 
+#### LCP
+
+* [#204](https://github.com/readium/kotlin-toolkit/issues/204) The `readium-lcp` module now ships consumer Proguard rules keeping the `liblcp` SDK classes, which are accessed through reflection. Apps enabling minification no longer need to declare these rules themselves.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/readium/lcp/build.gradle.kts
+++ b/readium/lcp/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
 
 android {
     namespace = "org.readium.r2.lcp"
+
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
 }
 
 kotlin {

--- a/readium/lcp/consumer-rules.pro
+++ b/readium/lcp/consumer-rules.pro
@@ -1,0 +1,5 @@
+# The liblcp SDK (org.readium.lcp.sdk.Lcp, DRMContext, DRMException, DRMError...)
+# is accessed only through reflection (see LcpClient), so R8/Proguard cannot detect
+# its usage and would otherwise strip or rename it in minified integrator apps.
+# See https://github.com/readium/kotlin-toolkit/issues/204
+-keep class org.readium.lcp.sdk.** { *; }


### PR DESCRIPTION
`LcpClient` reaches the liblcp SDK (`Lcp`, `DRMContext`, `DRMException`, `DRMError`) exclusively through reflection, so R8/Proguard strips or renames `org.readium.lcp.sdk` classes in minified apps, breaking `LicenseValidation`. Every integrator had to rediscover and declare the keep rules manually.

The `readium-lcp` module now ships a `consumer-rules.pro` file — bundled in the AAR and applied automatically to consumer apps — keeping `org.readium.lcp.sdk.**`.

Fixes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)