### PR TITLE
Fix AudioNavigator.go() ignoring progression-only locators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
 
+#### Navigator
+
+* [#771](https://github.com/readium/kotlin-toolkit/issues/771) Calling `go()` on the `AudioNavigator` with a locator containing only a `progression` (no time fragment) now seeks proportionally to the resource duration, instead of restarting the audio file from the beginning.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/readium/navigators/media/audio/src/main/java/org/readium/navigator/media/audio/AudioNavigator.kt
+++ b/readium/navigators/media/audio/src/main/java/org/readium/navigator/media/audio/AudioNavigator.kt
@@ -179,7 +179,10 @@ public class AudioNavigator<S : Configurable.Settings, P : Configurable.Preferen
         val itemIndex = readingOrder.items.indexOfFirst { it.href == locator.href }
             .takeUnless { it == -1 }
             ?: return false
-        val position = locator.locations.time ?: Duration.ZERO
+        val position = locator.locations.time
+            ?: locator.locations.progression?.coerceIn(0.0, 1.0)
+                ?.let { progression -> readingOrder.items[itemIndex].duration?.times(progression) }
+            ?: Duration.ZERO
         Timber.v("Go to locator $locator")
         audioEngine.skipTo(itemIndex, position)
         return true


### PR DESCRIPTION
Calling `go()` on `AudioNavigator` with a locator carrying only a `progression` (no `t=` time fragment) restarted the resource from 0s, because only `locations.time` was consulted. The seek position now falls back to `progression × item duration` (progression clamped to 0–1), mirroring how `currentLocator` computes progression, and defaults to zero only when neither is available.

The TTS side of the issue lives in the shared content iterators (`HtmlResourceContentIterator` only honors `cssSelector` for mid-resource starts) and is left for a follow-up issue, since fixing it changes shared-module behavior for all `ContentService` consumers.

Fixes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)