### PR TITLE
Fix retrieving an expired LCP license to allow renewing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file. Take a look
 
 * EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
 
+#### LCP
+
+* [#772](https://github.com/readium/kotlin-toolkit/issues/772) Fixed retrieving an expired LCP license, to be able to renew it. `LcpService.retrieveLicense()` and `publication.lcpLicense` now return the license even when its status is not valid (e.g. expired, returned or revoked), matching the behavior of the Swift toolkit. Decrypting content with such a license still fails with the corresponding `LcpError.LicenseStatus` error.
+    * **Note**: as a result, opening a publication with an expired license no longer reports it as restricted: `ContentProtectionService.isRestricted` is now `false` and `publication.protectionError` is `null`. If you relied on `protectionError` to detect an expired license, check `lcpLicense.status` instead, or handle the `LcpError.LicenseStatus` decryption errors while rendering the publication.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/readium/lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -358,21 +358,19 @@ internal class LicensesService(
         validation.validate(LicenseValidation.Document.license(initialData)) { documents, error ->
             documents?.let {
                 Timber.d("validated documents $it")
-                try {
-                    documents.getContext()
-                    launch {
-                        completion(
-                            License(
-                                documents = it,
-                                validation = validation,
-                                licenses = this@LicensesService.licenses,
-                                device = this@LicensesService.device,
-                                httpClient = this@LicensesService.httpClient
-                            )
+                // Note: the license context is not eagerly validated here, to be able to return a
+                // `License` even when the license is expired (e.g. to renew it). Any status error
+                // will be thrown when calling `License.decrypt()`, mirroring the Swift toolkit.
+                launch {
+                    completion(
+                        License(
+                            documents = it,
+                            validation = validation,
+                            licenses = this@LicensesService.licenses,
+                            device = this@LicensesService.device,
+                            httpClient = this@LicensesService.httpClient
                         )
-                    }
-                } catch (e: Exception) {
-                    throw e
+                    )
                 }
             }
             error?.let { throw error }


### PR DESCRIPTION
`LcpService.retrieveLicense()` eagerly resolved the DRM context, which throws for licenses whose status is no longer valid (expired, returned, revoked), so no `License` was ever returned and renewal was impossible on Android — while the Swift toolkit allows it (its `LicensesService` resolves the context lazily, only at decryption time).

The eager `getContext()` check is removed so the `License` is returned after successful validation. Decrypting content with such a license still fails with the corresponding `LcpError.LicenseStatus` error, surfaced lazily by `License.decrypt()`. Also removes a no-op `try/catch` around the removed call.

**Behavior change:** opening a publication with an expired license no longer reports it as restricted (`isRestricted` is `false`, `publication.protectionError` is `null`). Apps that relied on `protectionError` to detect expiry should check `lcpLicense.status` or handle `LcpError.LicenseStatus` decryption errors instead. This matches iOS and is called out in the CHANGELOG.

Fixes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)