### PR TITLE
Fix audio focus handling in the TTS navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 * EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
 
+#### Navigator
+
+* [#615](https://github.com/readium/kotlin-toolkit/issues/615) Fixed audio focus handling in the TTS navigator:
+    * The TTS playback now pauses on a transient audio focus loss (e.g. a notification or an assistant speaking) and resumes automatically when focus is regained.
+    * The `handleAudioFocus` parameter of `Player.setAudioAttributes()` is now honored, allowing apps to disable the automatic audio focus handling on the `Player` instance returned by `TtsNavigator.asMedia3Player()`.
+
 
 ## [3.3.0] - 2026-06-02
 

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/AudioFocusManager.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/AudioFocusManager.kt
@@ -137,6 +137,7 @@ internal class AudioFocusManager(
     fun setAudioAttributes(audioAttributes: AudioAttributes?) {
         if (!Objects.equals(this.audioAttributes, audioAttributes)) {
             this.audioAttributes = audioAttributes
+            rebuildAudioFocusRequest = true
             focusGainToRequest = convertAudioAttributesToFocusGain(audioAttributes)
             require(
                 focusGainToRequest == AUDIOFOCUS_GAIN || focusGainToRequest == AUDIOFOCUS_NONE

--- a/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
+++ b/readium/navigators/media/tts/src/main/java/org/readium/navigator/media/tts/session/TtsSessionAdapter.kt
@@ -78,6 +78,18 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
     private var lastPlaybackParameters: PlaybackParameters =
         playbackParametersState.value
 
+    private var audioAttributes: AudioAttributes =
+        AudioAttributes.Builder()
+            .setUsage(USAGE_MEDIA)
+            .setContentType(AUDIO_CONTENT_TYPE_SPEECH)
+            .setAllowedCapturePolicy(ALLOW_CAPTURE_BY_SYSTEM)
+            .build()
+
+    /**
+     * Whether playback should resume when audio focus is regained after a transient loss.
+     */
+    private var playAgainOnFocusGain: Boolean = false
+
     private val streamVolumeManager = StreamVolumeManager(
         application,
         eventHandler,
@@ -125,10 +137,7 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
             .onEach { playback ->
                 notifyListenersPlaybackChanged(lastPlayback, playback)
                 lastPlayback = playback
-                audioFocusManager.updateAudioFocus(
-                    playback.playWhenReady,
-                    playback.state.playerCode
-                )
+                updateAudioFocus(playback)
             }.launchIn(coroutineScope)
 
         playbackParametersState
@@ -278,6 +287,7 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
     }
 
     override fun setPlayWhenReady(playWhenReady: Boolean) {
+        playAgainOnFocusGain = false
         if (playWhenReady) {
             ttsPlayer.play()
         } else {
@@ -637,11 +647,7 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
     }
 
     override fun getAudioAttributes(): AudioAttributes {
-        return AudioAttributes.Builder()
-            .setUsage(USAGE_MEDIA)
-            .setContentType(AUDIO_CONTENT_TYPE_SPEECH)
-            .setAllowedCapturePolicy(ALLOW_CAPTURE_BY_SYSTEM)
-            .build()
+        return audioAttributes
     }
 
     override fun setVolume(volume: Float) {
@@ -745,7 +751,35 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
     }
 
     override fun setAudioAttributes(audioAttributes: AudioAttributes, handleAudioFocus: Boolean) {
-        audioFocusManager.setAudioAttributes(audioAttributes)
+        if (this.audioAttributes != audioAttributes) {
+            this.audioAttributes = audioAttributes
+            streamVolumeManager.setStreamType(audioAttributes.volumeControlStream)
+            listeners.sendEvent(
+                EVENT_AUDIO_ATTRIBUTES_CHANGED
+            ) { listener: Listener ->
+                listener.onAudioAttributesChanged(audioAttributes)
+            }
+        }
+
+        // Passing null audio attributes disables audio focus handling.
+        audioFocusManager.setAudioAttributes(audioAttributes.takeIf { handleAudioFocus })
+        updateAudioFocus(ttsPlayer.playback.value)
+    }
+
+    /**
+     * Requests or abandons audio focus according to the given playback state, pausing playback
+     * if focus is denied.
+     */
+    private fun updateAudioFocus(playback: TtsPlayer.Playback) {
+        val playerCommand = audioFocusManager.updateAudioFocus(
+            playback.playWhenReady,
+            playback.state.playerCode
+        )
+        if (playerCommand == AudioFocusManager.PLAYER_COMMAND_DO_NOT_PLAY && playback.playWhenReady) {
+            // Pause through ttsPlayer directly instead of setPlayWhenReady: this pause reflects
+            // the focus state, not a user intent, so it must not clear playAgainOnFocusGain.
+            ttsPlayer.pause()
+        }
     }
 
     private fun notifyListenersPlaybackChanged(
@@ -876,7 +910,26 @@ internal class TtsSessionAdapter<E : TtsEngine.Error>(
         }
 
         override fun executePlayerCommand(playerCommand: Int) {
-            playWhenReady = playWhenReady && playerCommand != AudioFocusManager.PLAYER_COMMAND_DO_NOT_PLAY
+            when (playerCommand) {
+                AudioFocusManager.PLAYER_COMMAND_DO_NOT_PLAY -> {
+                    // Permanent focus loss: pause and don't resume automatically.
+                    playWhenReady = false
+                }
+                AudioFocusManager.PLAYER_COMMAND_WAIT_FOR_CALLBACK -> {
+                    // Transient focus loss: pause and resume when focus is regained.
+                    // The ordering matters: setting playWhenReady clears playAgainOnFocusGain
+                    // through setPlayWhenReady, so the flag must be set afterwards.
+                    val playAgain = playWhenReady
+                    playWhenReady = false
+                    playAgainOnFocusGain = playAgain
+                }
+                AudioFocusManager.PLAYER_COMMAND_PLAY_WHEN_READY -> {
+                    // Focus (re)gained: resume only if we paused because of a transient loss.
+                    if (playAgainOnFocusGain) {
+                        playWhenReady = true
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes two distinct bugs (plus one latent) in `TtsSessionAdapter` / `AudioFocusManager`:

- **Opt-out ignored**: the `handleAudioFocus` parameter of `Player.setAudioAttributes()` was dropped, so the toolkit's own focus request — re-issued on every playback state emission — immediately stole focus back from apps managing it themselves (the reported "focus immediately lost"). It's now honored with ExoPlayer's exact semantics (null attributes → abandon and stop requesting), and `getAudioAttributes()` now returns the real attributes.
- **Transient loss ignored**: `PLAYER_COMMAND_WAIT_FOR_CALLBACK` (notification, assistant, duck-on-speech) was a no-op. TTS now pauses on transient loss and resumes automatically on regain; a manual pause during an interruption sticks.
- **Denied focus ignored**: the result of `updateAudioFocus()` was discarded, so playback could start during a phone call; it no longer does. The API-26 `AudioFocusRequest` is also rebuilt when attributes change.

The audiobook navigator is unaffected — ExoPlayer natively implements both behaviors.

**Needs on-device testing**: (1) notification/assistant interruption pauses and resumes TTS; (2) another app's music pauses TTS permanently; (3) opt-out via `setAudioAttributes(attrs, false)` lets the app keep focus; (4) TTS doesn't start during a phone call.

Fixes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)