### PR TITLE
Fix Google Play Console flagging the test app's deep links

### DIFF
--- a/docs/guides/open-publication.md
+++ b/docs/guides/open-publication.md
@@ -84,3 +84,9 @@ The `AssetRetriever` offers an additional constructor that provides greater exte
 * `FormatSniffer` which identifies the file formats that `AssetRetriever` can recognize.
 
 You can use either the default implementations or implement your own for each of these components using the composite pattern. The toolkit's `CompositeResourceFactory`, `CompositeArchiveOpener`, and `CompositeFormatSniffer` provide a simple resolution strategy.
+
+## Accepting publications shared by other apps (side loading)
+
+To let users open publications in your app from a file manager, an email client or a browser download, declare intent filters for the `VIEW` and `SEND` actions on the activity handling imports. The [test app manifest](https://github.com/readium/kotlin-toolkit/blob/develop/test-app/src/main/AndroidManifest.xml) demonstrates a working setup, matching both media types and file extensions.
+
+A word of warning: restrict the `VIEW` filters to the `content` (and legacy `file`) schemes. Declaring the `http`/`https` schemes with a wildcard host will make the Google Play Console flag your app during deep link validation ("Direct links don't work"), as it cannot verify a wildcard domain. These web schemes are unnecessary for side loading, since apps and browsers deliver files through `content://` URIs.

--- a/test-app/src/main/AndroidManifest.xml
+++ b/test-app/src/main/AndroidManifest.xml
@@ -67,6 +67,12 @@
 
             4. `android:pathPattern` is case sensitive and is not using a true regex (it's just
                 globbing), so we need to match the uppercase versions of file extensions as well.
+
+            5. Don't declare the `http` and `https` schemes (nor the BROWSABLE category) in the
+               VIEW filters. Combined with a wildcard host, they fail the Google Play Console
+               deep link validation ("Direct links don't work", see issue #426). They are not
+               needed for side loading: apps and browsers hand files over with `content://` (or
+               legacy `file://`) URIs.
             -->
 
             <!-- SEND (Share) action -->
@@ -75,7 +81,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
 
                 <!-- WARNING: Don't set `android:scheme` because it will break the matching. -->
 
@@ -110,13 +115,9 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="app" />
                 <data android:scheme="content" />
                 <data android:scheme="file" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
 
                 <!-- Audiobook (Readium) -->
                 <data android:mimeType="application/audiobook+zip" />
@@ -147,15 +148,11 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:host="*" />
 
-                <data android:scheme="app" />
                 <data android:scheme="content" />
                 <data android:scheme="file" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
 
                 <!-- This media type is necessary, otherwise it won't match on the file extension -->
                 <data android:mimeType="*/*" />


### PR DESCRIPTION
The Play Console flagged the test app with "Direct links don't work" because the `ImportActivity` `VIEW` intent filters declared `http`/`https` schemes with a wildcard host, which deep link validation cannot verify.

These schemes (and `BROWSABLE`) are unnecessary for side-loading: apps and browsers hand files over via `content://` URIs, and a shared URL still reaches the HTTP import path through the `SEND text/plain` filter. The `VIEW` filters are now restricted to the `content` and `file` schemes, the vestigial `app` scheme is dropped, the rationale is documented in the manifest, and the "Opening a publication" guide gains a short side-loading section pointing at the manifest as the reference pattern.

No library code changed — test app and docs only.

Fixes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)